### PR TITLE
Do not include /usr/include with isystem

### DIFF
--- a/qskconfig.pri
+++ b/qskconfig.pri
@@ -62,7 +62,6 @@ linux {
         # to exclude them by declaring them as system includes
 
         QMAKE_CXXFLAGS += \
-            -isystem $$[QT_INSTALL_HEADERS] \
             -isystem $$[QT_INSTALL_HEADERS]/QtCore \
             -isystem $$[QT_INSTALL_HEADERS]/QtGui \
             -isystem $$[QT_INSTALL_HEADERS]/QtGui/$$[QT_VERSION]/QtGui \


### PR DESCRIPTION
gcc 8.2 fails with:

|  /usr/include/c++/8.2.0/cstdlib:75:15: fatal error: stdlib.h: No such file or directory
|  #include_next <stdlib.h>
|                ^~~~~~~~~~

More details are found at [1]

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>