### PR TITLE
Support building on macOS

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,0 +1,1 @@
+QMAKEFEATURES=$$PWD/features

--- a/features/default_post.prf
+++ b/features/default_post.prf
@@ -1,0 +1,7 @@
+load(default_post)
+
+darwin:equals(TEMPLATE, lib) {
+    # Add install name to all libraries, including plugins
+    LIBS += -Wl,-install_name,@rpath/lib$${TARGET}.dylib
+}
+


### PR DESCRIPTION
Some changes I needed to do, to make it build and run on macOS. Basically every lib/plugin needs to set an install name, unless you want to twiddle with setting DYLD_LIBRARY_PATH etc. Also, since the skin plugins are linked in directly in the examples as a if they were normal libs, I needed to add _debug suffix to them when building in debug mode.