### PR TITLE
Fix cross compilation build for ARM

### DIFF
--- a/examples/automotive/automotive.pro
+++ b/examples/automotive/automotive.pro
@@ -59,8 +59,13 @@ SVGSOURCES = \
 # writing application project files.
 ###########
 
-# Convert path to shell path, otherwise it fails on Windows.
-SVG2QVG=$$shell_path($${QSK_OUT_ROOT}/tools/bin/svg2qvg)
+cross_compile {
+    # for now just assume that a desktop version of the tool is in the path
+    SVG2QVG=svg2qvg
+} else {
+    # Convert path to shell path, otherwise it fails on Windows.
+    SVG2QVG=$$shell_path($${QSK_OUT_ROOT}/tools/bin/svg2qvg)
+}
 
 svg2qvg.name = SVG compiler
 svg2qvg.input = SVGSOURCES

--- a/examples/qvgviewer/qvgviewer.pro
+++ b/examples/qvgviewer/qvgviewer.pro
@@ -16,8 +16,13 @@ SVGSOURCES = \
     svg/01.08.05q.svg \
     svg/01.25.18.svg
 
-# Convert path to shell path, otherwise it fails on Windows.
-SVG2QVG=$$shell_path($${QSK_OUT_ROOT}/tools/bin/svg2qvg)
+cross_compile {
+    # for now just assume that a desktop version of the tool is in the path
+    SVG2QVG=svg2qvg
+} else {
+    # Convert path to shell path, otherwise it fails on Windows.
+    SVG2QVG=$$shell_path($${QSK_OUT_ROOT}/tools/bin/svg2qvg)
+}
 
 svg2qvg.name = SVG compiler
 svg2qvg.input = SVGSOURCES

--- a/features/qskconfig.pri
+++ b/features/qskconfig.pri
@@ -23,6 +23,7 @@ QSK_INSTALL_HEADERS   = $${QSK_INSTALL_PREFIX}/include
 QSK_INSTALL_LIBS      = $${QSK_INSTALL_PREFIX}/lib
 QSK_INSTALL_BINS      = $${QSK_INSTALL_PREFIX}/bin
 QSK_INSTALL_PLUGINS   = $${QSK_INSTALL_PREFIX}/plugins
+QSK_INSTALL_EXAMPLES  = $${QSK_INSTALL_PREFIX}/examples
 
 CONFIG           += no_private_qt_headers_warning
 

--- a/features/qskexample.prf
+++ b/features/qskexample.prf
@@ -3,3 +3,6 @@ CONFIG      += qskinny qsktestsupport
 
 DEFINES     += QSK_DLL
 DESTDIR      = $$clean_path( $${OUT_PWD}/../bin )
+
+target.path    = $${QSK_INSTALL_EXAMPLES}
+INSTALLS       = target

--- a/features/qsktestsupport.prf
+++ b/features/qsktestsupport.prf
@@ -5,3 +5,6 @@ DEPENDPATH  *= $${QSK_TEST_SUPPORT_DIRS}
 
 QMAKE_RPATHDIR *= $${QSK_LIB_DIR}
 qskAddLibrary( $${QSK_LIB_DIR}, qsktestsupport)
+
+qskAddLibrary( $${QSK_PLUGIN_DIR}/skins, squiekskin)
+qskAddLibrary( $${QSK_PLUGIN_DIR}/skins, materialskin)

--- a/support/support.pro
+++ b/support/support.pro
@@ -51,3 +51,6 @@ fontconfig {
 
     DEFINES += FONTCONFIG_FILE=$$clean_path( $$QSK_FONTCONF_FILE )
 }
+
+target.path    = $${QSK_INSTALL_LIBS}
+INSTALLS       = target

--- a/tools/tools.pro
+++ b/tools/tools.pro
@@ -1,6 +1,6 @@
 TEMPLATE = subdirs
 
-qtHaveModule(svg) {
+qtHaveModule(svg):!cross_compile {
 
     SUBDIRS += \
         svg2qvg


### PR DESCRIPTION
* Add some INSTALLS directives to .pro files. They are used by
  QtCreator to deploy code to target devices, so it makes sense to
  deploy the examples and test support library as well.
* Add the skins plugins explicitly when adding test support;
  otherwise this won't build. This Might be a problem of the toolchain
  though.