### PR TITLE
Don't replace saqt documentation tags

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -263,8 +263,7 @@ ALIASES                = "accessors=\par Access functions:^^" \
                          "subcontrols=\par Subcontrols:^^" \
                          "states=\par States:^^" \
                          "skinlet=\par Default Skinlet:^^" \
-                         "aspect=\par Aspect^^" \
-                         "saqt=\sa ^^"
+                         "aspect=\par Aspect^^"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/doc/classes/QskControl.dox
+++ b/doc/classes/QskControl.dox
@@ -30,7 +30,7 @@
         A state bit that is set, when the item is the active focus item
 
     \sa   focusPolicy
-    \saqt QQuickItem::acceptHoverEvents(), QQuickItem::focusInEvent()
+    \saqt QQuickItem::acceptHoverEvents(), QQuickItem::focusInEvent(),
           QQuickItem::focusOutEvent()
 */
 


### PR DESCRIPTION
It is easier for us to parse those special tags in Doxybook, too bad we cannot hook into the tags right in Doxygen.
The current version of the website already contains those commits.