### PR TITLE
QskProgressBar: Don't hardcode orientation of gradient

### DIFF
--- a/src/controls/QskProgressBarSkinlet.cpp
+++ b/src/controls/QskProgressBarSkinlet.cpp
@@ -124,8 +124,6 @@ QSGNode* QskProgressBarSkinlet::updateBarNode(
     if ( !gradient.isVisible() )
         return nullptr;
 
-    gradient.setOrientation( bar->orientation() );
-
     if ( !gradient.isMonochrome() )
     {
         const auto intv = qskBarInterval( bar );


### PR DESCRIPTION
It makes sense to have a vertical gradient on a horizontal progress
bar etc.