### PR TITLE
QskTabBar: Respect alignment hint

### DIFF
--- a/examples/tabview/main.cpp
+++ b/examples/tabview/main.cpp
@@ -13,6 +13,7 @@
 #include <QskObjectCounter.h>
 #include <QskPushButton.h>
 #include <QskSkin.h>
+#include <QskSimpleListBox.h>
 #include <QskTabButton.h>
 #include <QskTabBar.h>
 #include <QskTabView.h>
@@ -53,6 +54,7 @@ class TabView : public QskTabView
 
         buttonAt( 2 )->setEnabled( false );
         setCurrentIndex( 4 );
+        setAutoFitTabs(false);
     }
 
     void appendTab()
@@ -79,6 +81,39 @@ class TabView : public QskTabView
                 break;
             }
         }
+    }
+
+    void updateAlignment( const QString& hAlignment, const QString& vAlignment )
+    {
+        Qt::Alignment alignment;
+
+        if( hAlignment == QStringLiteral( "align left" ) )
+        {
+            alignment |= Qt::AlignLeft;
+        }
+        else if( hAlignment == QStringLiteral( "align center" ) )
+        {
+            alignment |= Qt::AlignHCenter;
+        }
+        else if( hAlignment == QStringLiteral( "align right" ) )
+        {
+            alignment |= Qt::AlignRight;
+        }
+
+        if( vAlignment == QStringLiteral( "align top" ) )
+        {
+            alignment |= Qt::AlignTop;
+        }
+        else if( vAlignment == QStringLiteral( "align middle" ) )
+        {
+            alignment |= Qt::AlignVCenter;
+        }
+        else if( vAlignment == QStringLiteral( "align bottom" ) )
+        {
+            alignment |= Qt::AlignBottom;
+        }
+
+        setTabAlignment( alignment );
     }
 };
 
@@ -113,12 +148,35 @@ int main( int argc, char* argv[] )
     QObject::connect( removeButton, &QskPushButton::clicked,
         tabView, &TabView::removeLastTab );
 
+    auto hAlignmentBox = new QskSimpleListBox();
+    hAlignmentBox->append( "align left" );
+    hAlignmentBox->append( "align center" );
+    hAlignmentBox->append( "align right" );
+
+    auto vAlignmentBox = new QskSimpleListBox();
+    vAlignmentBox->append( "align top" );
+    vAlignmentBox->append( "align middle" );
+    vAlignmentBox->append( "align bottom" );
+
+    auto alignmentLambda = [ tabView, hAlignmentBox, vAlignmentBox ]()
+        {
+            tabView->updateAlignment( hAlignmentBox->selectedEntry(),
+                vAlignmentBox->selectedEntry() );
+        };
+
+    QObject::connect( hAlignmentBox, &QskSimpleListBox::selectedEntryChanged,
+        alignmentLambda );
+    QObject::connect( vAlignmentBox, &QskSimpleListBox::selectedEntryChanged,
+        alignmentLambda );
+
     auto buttonBox = new QskLinearBox( Qt::Horizontal );
     buttonBox->addItem( rotateButton );
     buttonBox->addItem( autoFitButton );
     buttonBox->addItem( addButton );
     buttonBox->addItem( removeButton );
-    buttonBox->setSizePolicy( QskSizePolicy::Fixed, QskSizePolicy::Fixed );
+    buttonBox->addItem( hAlignmentBox );
+    buttonBox->addItem( vAlignmentBox );
+    buttonBox->setSizePolicy( QskSizePolicy::Preferred, QskSizePolicy::Fixed );
 
     auto layoutBox = new QskLinearBox( Qt::Vertical );
     layoutBox->setDefaultAlignment( Qt::AlignLeft );

--- a/src/controls/QskTabBar.h
+++ b/src/controls/QskTabBar.h
@@ -19,6 +19,9 @@ class QSK_EXPORT QskTabBar : public QskBox
     Q_PROPERTY( Qsk::Position tabPosition READ tabPosition
         WRITE setTabPosition NOTIFY tabPositionChanged FINAL )
 
+    Q_PROPERTY( Qt::Alignment tabAlignment READ tabAlignment
+        WRITE setTabAlignment NOTIFY tabAlignmentChanged FINAL )
+
     Q_PROPERTY( Qt::Orientation orientation READ orientation )
 
     Q_PROPERTY( bool autoScrollFocusButton READ autoScrollFocusButton
@@ -47,6 +50,9 @@ class QSK_EXPORT QskTabBar : public QskBox
 
     void setTabPosition( Qsk::Position );
     Qsk::Position tabPosition() const;
+
+    void setTabAlignment( Qt::Alignment );
+    Qt::Alignment tabAlignment() const;
 
     Qt::Orientation orientation() const;
 
@@ -99,6 +105,7 @@ class QSK_EXPORT QskTabBar : public QskBox
     void countChanged( int );
     void textOptionsChanged( const QskTextOptions& );
     void tabPositionChanged( Qsk::Position );
+    void tabAlignmentChanged( Qt::Alignment );
     void autoScrollFocusedButtonChanged( bool );
     void autoFitTabsChanged( bool );
 
@@ -111,6 +118,8 @@ class QSK_EXPORT QskTabBar : public QskBox
   private:
     void adjustCurrentIndex();
     void handleButtonClick();
+    void ensureSpacer( Qsk::Position position );
+    void removeSpacer( Qsk::Position position );
 
     class PrivateData;
     std::unique_ptr< PrivateData > m_data;

--- a/src/controls/QskTabView.cpp
+++ b/src/controls/QskTabView.cpp
@@ -70,6 +70,9 @@ QskTabView::QskTabView( Qsk::Position tabPosition, QQuickItem* parent )
     connect( m_data->tabBar, &QskTabBar::tabPositionChanged,
         this, &QskTabView::tabPositionChanged );
 
+    connect( m_data->tabBar, &QskTabBar::tabAlignmentChanged,
+        this, &QskTabView::tabAlignmentChanged );
+
     connect( m_data->tabBar, &QskTabBar::autoFitTabsChanged,
         this, &QskTabView::autoFitTabsChanged );
 }
@@ -102,6 +105,22 @@ void QskTabView::setTabPosition( Qsk::Position position )
 Qsk::Position QskTabView::tabPosition() const
 {
     return m_data->tabBar->tabPosition();
+}
+
+void QskTabView::setTabAlignment( Qt::Alignment alignment )
+{
+    if ( alignment == tabAlignment() )
+        return;
+
+    m_data->tabBar->setTabAlignment( alignment );
+
+    polish();
+    update();
+}
+
+Qt::Alignment QskTabView::tabAlignment() const
+{
+    return m_data->tabBar->tabAlignment();
 }
 
 void QskTabView::setAutoFitTabs( bool on )

--- a/src/controls/QskTabView.h
+++ b/src/controls/QskTabView.h
@@ -21,6 +21,9 @@ class QSK_EXPORT QskTabView : public QskControl
     Q_PROPERTY( Qsk::Position tabPosition READ tabPosition
         WRITE setTabPosition NOTIFY tabPositionChanged FINAL )
 
+    Q_PROPERTY( Qt::Alignment tabAlignment READ tabAlignment
+        WRITE setTabAlignment NOTIFY tabAlignmentChanged FINAL )
+
     Q_PROPERTY( bool autoFitTabs READ autoFitTabs
         WRITE setAutoFitTabs NOTIFY autoFitTabsChanged FINAL )
 
@@ -46,6 +49,9 @@ class QSK_EXPORT QskTabView : public QskControl
 
     void setTabPosition( Qsk::Position );
     Qsk::Position tabPosition() const;
+
+    void setTabAlignment( Qt::Alignment );
+    Qt::Alignment tabAlignment() const;
 
     void setAutoFitTabs( bool );
     bool autoFitTabs() const;
@@ -84,6 +90,7 @@ class QSK_EXPORT QskTabView : public QskControl
     void currentIndexChanged( int index );
     void countChanged( int );
     void tabPositionChanged( Qsk::Position );
+    void tabAlignmentChanged( Qt::Alignment );
     void autoFitTabsChanged( bool );
 
   protected:


### PR DESCRIPTION
The only solution I could find was to add spacers next to the button box. For some reason setting the extra space did not work, because the buttons would always take up the extra space, even when setting the size policy to fixed.