### PR TITLE
Windows: Fix placement policy of all items

### DIFF
--- a/src/common/QskPlacementPolicy.h
+++ b/src/common/QskPlacementPolicy.h
@@ -50,8 +50,8 @@ class QskPlacementPolicy
     constexpr Policy hiddenPolicy() const noexcept;
 
   private:
-    Policy m_visiblePolicy : 2;
-    Policy m_hiddenPolicy : 2;
+    Policy m_visiblePolicy : 3;
+    Policy m_hiddenPolicy : 3;
 };
 
 inline constexpr QskPlacementPolicy::QskPlacementPolicy() noexcept


### PR DESCRIPTION
Before, on Windows nothing would be displayed because of the
following error:

implicit truncation from 'QskPlacementPolicy::Policy' to bit-field
changes value from 2 to -2