### PR TITLE
CI: Use OpenGL backend on Windows

### DIFF
--- a/.github/workflows/qmake.yml
+++ b/.github/workflows/qmake.yml
@@ -244,6 +244,8 @@ jobs:
   build-windows-qt-lts:
     name: Windows Qt 6.2 (LTS) build
     runs-on: windows-latest
+    env:
+      QSG_RHI_BACKEND: opengl
     steps:
     - uses: actions/checkout@v2
     - name: Cache Qt
@@ -299,6 +301,8 @@ jobs:
   build-windows-qt-current:
     name: Windows Qt 6.3 (current) build
     runs-on: windows-latest
+    env:
+      QSG_RHI_BACKEND: opengl
     steps:
     - uses: actions/checkout@v2
     - name: Cache Qt


### PR DESCRIPTION
We currently don't support the D3D11 backend, since we rely on
OpenGL functionality when rendering textures, see e.g.
qskCreateTextureRaster().