### PR TITLE
switch button: Fix size hint

### DIFF
--- a/src/controls/QskSwitchButtonSkinlet.cpp
+++ b/src/controls/QskSwitchButtonSkinlet.cpp
@@ -67,7 +67,7 @@ QSizeF QskSwitchButtonSkinlet::sizeHint( const QskSkinnable* skinnable,
     auto handleHint = skinnable->strutSizeHint( QskSwitchButton::Handle );
     auto rippleHint = skinnable->strutSizeHint( QskSwitchButton::Ripple );
 
-    auto hint = grooveHint.expandedTo( grooveHint + rippleHint - handleHint );
+    auto hint = grooveHint;
     hint = hint.expandedTo( rippleHint );
     hint = hint.expandedTo( handleHint );
 


### PR DESCRIPTION
This fixes a case where the Groove is bigger than the Handle, e.g.
with the Material 3 switch buttons.