### PR TITLE
Popups: Remove clip when showing the popup

### DIFF
--- a/src/controls/QskPopupSkinlet.cpp
+++ b/src/controls/QskPopupSkinlet.cpp
@@ -149,8 +149,15 @@ QSGNode* QskPopupSkinlet::updateExtraNode( const QskPopup* popup, QSGNode* node 
     auto rootNode = QskSGNode::ensureNode< RootNode >( node );
 
     const auto faderProgress = popup->metric( popup->faderAspect() );
+
     if ( faderProgress > 0.0 && faderProgress < 1.0 )
+    {
         rootNode->setClipRect( cr );
+    }
+    else if( faderProgress <= 0.0 )
+    {
+        rootNode->setClipRect( {} );
+    }
 
     rootNode->setTranslation( 0.0, -faderProgress * cr.height() );
 


### PR DESCRIPTION
Otherwise we would clip the shadow, e.g. in the Material case.