### PR TITLE
color filter: Add option to also substitute alpha value

### DIFF
--- a/examples/gallery/button/ButtonPage.cpp
+++ b/examples/gallery/button/ButtonPage.cpp
@@ -17,7 +17,7 @@ namespace
     {
       public:
         ButtonBox( QQuickItem* parent = nullptr )
-            : QskLinearBox( Qt::Horizontal, 4, parent )
+            : QskLinearBox( Qt::Horizontal, 3, parent )
         {
             setSpacing( 20 );
             setExtraSpacingAt( Qt::BottomEdge );
@@ -29,90 +29,85 @@ namespace
       private:
         void populate()
         {
-            const char* texts[] = { "Press Me", "Check Me" };
+            auto* filledButton1 = new QskPushButton( this );
+            filledButton1->setGraphicSource( "airport_shuttle" );
+            filledButton1->setText( "normal" );
 
-            for ( int i = 0; i < 6; i++ )
-            {
-                const int index = i % 2;
+            auto* filledButton2 = new QskPushButton( this );
+            filledButton2->setText( "normal" );
 
-                auto button = new QskPushButton( this );
-                button->setCheckable( index != 0 );
-                //button->setSizePolicy( QskSizePolicy::Fixed, QskSizePolicy::Fixed );
+            auto* filledButton3 = new QskPushButton( this );
+            filledButton3->setGraphicSource( "airport_shuttle" );
 
-                if ( i > 1 )
-                {
-                    auto src = QStringLiteral( "plus" );
-                    button->setGraphicSource( src );
-                }
 
-                if ( i < 2 || i > 3 )
-                {
-                    button->setText( texts[ index ] );
-                }
-            }
+            auto* checkableButton1 = new QskPushButton( this );
+            checkableButton1->setGraphicSource( "airport_shuttle" );
+            checkableButton1->setText( "checkable" );
+            checkableButton1->setCheckable( true );
 
-            addSpacer( 0 );
-            addSpacer( 0 );
+            auto* checkableButton2 = new QskPushButton( this );
+            checkableButton2->setText( "checkable" );
+            checkableButton2->setCheckable( true );
+
+            auto* checkableButton3 = new QskPushButton( this );
+            checkableButton3->setGraphicSource( "airport_shuttle" );
+            checkableButton3->setCheckable( true );
+
 
             auto* outlinedButton1 = new QskPushButton( this );
             outlinedButton1->setEmphasis( QskPushButton::LowEmphasis );
-            outlinedButton1->setGraphicSource( "plus" );
-            outlinedButton1->setText( "Outlined" );
+            outlinedButton1->setGraphicSource( "flight" );
+            outlinedButton1->setText( "low emphasis" );
 
             auto* outlinedButton2 = new QskPushButton( this );
             outlinedButton2->setEmphasis( QskPushButton::LowEmphasis );
-            outlinedButton2->setText( "Outlined" );
+            outlinedButton2->setText( "low emphasis" );
 
             auto* outlinedButton3 = new QskPushButton( this );
             outlinedButton3->setEmphasis( QskPushButton::LowEmphasis );
-            outlinedButton3->setGraphicSource( "plus" );
+            outlinedButton3->setGraphicSource( "flight" );
 
-            addSpacer( 0 );
 
             auto* textButton1 = new QskPushButton( this );
             textButton1->setEmphasis( QskPushButton::VeryLowEmphasis );
-            textButton1->setGraphicSource( "plus" );
-            textButton1->setText( "Text" );
+            textButton1->setGraphicSource( "local_pizza" );
+            textButton1->setText( "very low emphasis" );
 
             auto* textButton2 = new QskPushButton( this );
             textButton2->setEmphasis( QskPushButton::VeryLowEmphasis );
-            textButton2->setText( "Text" );
+            textButton2->setText( "very low emphasis" );
 
             auto* textButton3 = new QskPushButton( this );
             textButton3->setEmphasis( QskPushButton::VeryLowEmphasis );
-            textButton3->setGraphicSource( "plus" );
+            textButton3->setGraphicSource( "local_pizza" );
 
-            addSpacer( 0 );
 
             auto* elevatedButton1 = new QskPushButton( this );
             elevatedButton1->setEmphasis( QskPushButton::HighEmphasis );
             elevatedButton1->setGraphicSource( "plus" );
-            elevatedButton1->setText( "Elevated" );
+            elevatedButton1->setText( "high emphasis" );
 
             auto* elevatedButton2 = new QskPushButton( this );
             elevatedButton2->setEmphasis( QskPushButton::HighEmphasis );
-            elevatedButton2->setText( "Elevated" );
+            elevatedButton2->setText( "high emphasis" );
 
             auto* elevatedButton3 = new QskPushButton( this );
             elevatedButton3->setEmphasis( QskPushButton::HighEmphasis );
             elevatedButton3->setGraphicSource( "plus" );
 
-            addSpacer( 0 );
 
             auto* tonalButton1 = new QskPushButton( this );
             tonalButton1->setEmphasis( QskPushButton::VeryHighEmphasis );
-            tonalButton1->setGraphicSource( "plus" );
-            tonalButton1->setText( "Tonal" );
+            tonalButton1->setGraphicSource( "sports_soccer" );
+            tonalButton1->setText( "very high emphasis" );
 
             auto* tonalButton2 = new QskPushButton( this );
             tonalButton2->setEmphasis( QskPushButton::VeryHighEmphasis );
-            tonalButton2->setText( "Tonal" );
+            tonalButton2->setText( "very high emphasis" );
 
             auto* tonalButton3 = new QskPushButton( this );
             tonalButton3->setEmphasis( QskPushButton::VeryHighEmphasis );
-            tonalButton3->setGraphicSource( "plus" );
-
-            addSpacer( 0 );
+            tonalButton3->setGraphicSource( "sports_soccer" );
         }
     };
 

--- a/skins/material3/QskMaterial3Skin.cpp
+++ b/skins/material3/QskMaterial3Skin.cpp
@@ -410,32 +410,33 @@ void Editor::setupTextInput()
 {
     using Q = QskTextInput;
 
-    setAlignment( Q::Text, Qt::AlignLeft | Qt::AlignTop );
-
-    setColor( Q::Text, m_pal.onBackground );
-
-    setPadding( Q::Panel, 5_dp );
-    setBoxShape( Q::Panel, 4_dp, 4_dp, 0, 0 );
-    setBoxBorderMetrics( Q::Panel, 0, 0, 0, 1_dp );
-    setBoxBorderColors( Q::Panel, m_pal.onSurface );
-
-    setBoxBorderMetrics( Q::Panel | Q::Focused, 0, 0, 0, 2_dp );
-    setBoxBorderColors( Q::Panel | Q::Focused, m_pal.primary );
-
-    setBoxBorderMetrics( Q::Panel | Q::Editing, 0, 0, 0, 2_dp );
-    setBoxBorderColors( Q::Panel | Q::Editing, m_pal.primary );
-
-    setBoxBorderMetrics( Q::Panel | Q::Hovered, 0, 0, 0, 1_dp );
-    setBoxBorderColors( Q::Panel | Q::Hovered, m_pal.onSurface );
-
+    setStrutSize( Q::Panel,  -1.0, 56_dp );
+    setPadding( Q::Panel, { 12_dp, 8_dp, 12_dp, 8_dp } );
     setGradient( Q::Panel, m_pal.surfaceVariant );
+    setBoxShape( Q::Panel, m_pal.shapeExtraSmallTop );
+    setBoxBorderMetrics( Q::Panel, { 0, 0, 0, 1_dp } );
+    setBoxBorderColors( Q::Panel, m_pal.onSurfaceVariant );
+    setSpacing( Q::Panel, 8_dp );
 
-    const auto c1 = QskRgb::toTransparentF( m_pal.onSurface, 0.04 );
-    setGradient( Q::Panel | Q::Disabled, c1 );
-    setBoxBorderMetrics( Q::Panel | Q::Disabled, 0, 0, 0, 1_dp );
+    const auto hoverColor = flattenedColor( m_pal.onSurfaceVariant,
+        m_pal.surfaceVariant, m_pal.hoverOpacity );
+    setGradient( Q::Panel | Q::Hovered, hoverColor );
+
+    const auto focusColor = flattenedColor( m_pal.onSurfaceVariant,
+        m_pal.surfaceVariant, m_pal.focusOpacity );
+    setGradient( Q::Panel | Q::Focused, focusColor );
+
+    // ### Also add a pressed state
+
+    setColor( Q::Text, m_pal.onSurface );
+    setFontRole( Q::Text, QskMaterial3Skin::M3BodyMedium );
+    setAlignment( Q::Text, Qt::AlignLeft | Qt::AlignVCenter );
+
+    const auto disabledPanelColor = QskRgb::toTransparentF( m_pal.onSurface, 0.04 );
+    setGradient( Q::Panel | Q::Disabled, disabledPanelColor );
+    setBoxBorderColors( Q::Panel | Q::Disabled, m_pal.onSurface38 );
 
     setColor( Q::Text | Q::Disabled, m_pal.onSurface38 );
-    setBoxBorderColors( Q::Panel | Q::Disabled, m_pal.onSurface38 );
 }
 
 void Editor::setupProgressBar()

--- a/skins/material3/QskMaterial3Skin.cpp
+++ b/skins/material3/QskMaterial3Skin.cpp
@@ -670,6 +670,7 @@ void Editor::setupPushButton()
 
     setColor( Q::Text, m_pal.onPrimary );
     setColor( Q::Text | Q::Disabled, m_pal.onSurface38 );
+    setGraphicRole( Q::Graphic | Q::Disabled, QskMaterial3Skin::GraphicRoleOnSurface38 );
 
     setTextOptions( Q::Text, Qt::ElideMiddle, QskTextOptions::NoWrap );
 
@@ -1337,34 +1338,42 @@ void QskMaterial3Skin::setupFonts()
 void QskMaterial3Skin::setupGraphicFilters( const QskMaterial3Theme& palette )
 {
     QskColorFilter onPrimaryFilter;
+    onPrimaryFilter.setSubstituteAlphaValue( true );
     onPrimaryFilter.addColorSubstitution( Qt::white, palette.onPrimary );
     setGraphicFilter( GraphicRoleOnPrimary, onPrimaryFilter );
 
     QskColorFilter onSecondaryContainerFilter;
+    onSecondaryContainerFilter.setSubstituteAlphaValue( true );
     onSecondaryContainerFilter.addColorSubstitution( Qt::white, palette.onSecondaryContainer );
     setGraphicFilter( GraphicRoleOnSecondaryContainer, onSecondaryContainerFilter );
 
     QskColorFilter onErrorFilter;
+    onErrorFilter.setSubstituteAlphaValue( true );
     onErrorFilter.addColorSubstitution( Qt::white, palette.onError );
     setGraphicFilter( GraphicRoleOnError, onErrorFilter );
 
     QskColorFilter onSurfaceFilter;
+    onSurfaceFilter.setSubstituteAlphaValue( true );
     onSurfaceFilter.addColorSubstitution( Qt::white, palette.onSurface );
     setGraphicFilter( GraphicRoleOnSurface, onSurfaceFilter );
 
     QskColorFilter onSurfaceFilter38;
+    onSurfaceFilter38.setSubstituteAlphaValue( true );
     onSurfaceFilter38.addColorSubstitution( Qt::white, palette.onSurface38 );
     setGraphicFilter( GraphicRoleOnSurface38, onSurfaceFilter38 );
 
     QskColorFilter onSurfaceVariantFilter;
+    onSurfaceVariantFilter.setSubstituteAlphaValue( true );
     onSurfaceVariantFilter.addColorSubstitution( Qt::white, palette.onSurfaceVariant );
     setGraphicFilter( GraphicRoleOnSurfaceVariant, onSurfaceVariantFilter );
 
     QskColorFilter primaryFilter;
+    primaryFilter.setSubstituteAlphaValue( true );
     primaryFilter.addColorSubstitution( Qt::white, palette.primary );
     setGraphicFilter( GraphicRolePrimary, primaryFilter );
 
     QskColorFilter surfaceFilter;
+    surfaceFilter.setSubstituteAlphaValue( true );
     surfaceFilter.addColorSubstitution( Qt::white, palette.surface );
     setGraphicFilter( GraphicRoleSurface, surfaceFilter );
 }

--- a/src/graphic/QskColorFilter.h
+++ b/src/graphic/QskColorFilter.h
@@ -37,6 +37,9 @@ class QSK_EXPORT QskColorFilter
 
     bool isIdentity() const noexcept;
 
+    bool substituteAlphaValue() const noexcept;
+    void setSubstituteAlphaValue( bool );
+
     bool operator==( const QskColorFilter& other ) const noexcept;
     bool operator!=( const QskColorFilter& other ) const noexcept;
 
@@ -51,6 +54,7 @@ class QSK_EXPORT QskColorFilter
 
   private:
     QVector< QPair< QRgb, QRgb > > m_substitutions;
+    bool m_substituteAlphaValue = false;
 };
 
 inline bool QskColorFilter::isIdentity() const noexcept


### PR DESCRIPTION
We need something along the lines of the patch; we could also make the flag per substitution?

But at least for Material we need it always, so for now I added it as a class member.

Before:

![Screenshot from 2023-02-24 15-48-48](https://user-images.githubusercontent.com/1749504/221208666-b6c789b4-9068-4ffa-98ff-d39999073a39.png)

After:

![Screenshot from 2023-02-24 15-47-47](https://user-images.githubusercontent.com/1749504/221208704-d986a9bb-3522-48ba-b3eb-67732a073912.png)
