### PR TITLE
Adjust generated target's folder property

### DIFF
--- a/cmake/QskConfigMacros.cmake
+++ b/cmake/QskConfigMacros.cmake
@@ -163,3 +163,23 @@ macro(qsk_finalize_build_flags)
     endif()
 
 endmacro()
+
+function(qsk_internal_sync_generated_target_folder directory)
+    # loop through all targets in the directory recursively and
+    # synchronize the generated target's folder property with 
+    # the actual target's folder property
+    get_property(TARGETS DIRECTORY "${directory}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(target IN LISTS TARGETS)
+        if(TARGET ${target}_qmlimportscan)
+            get_target_property(folder ${target} FOLDER)
+            set_target_properties(${target}_qmlimportscan PROPERTIES FOLDER ${folder})
+            message(DEBUG "Adjusting target '${target}_qmlimportscan' folder property to ${target}'s folder property '${folder}'")
+        endif()
+    endforeach()
+
+    # scan directory recursively
+    get_property(SUBDIRS DIRECTORY "${directory}" PROPERTY SUBDIRECTORIES)
+    foreach(SUBDIR IN LISTS SUBDIRS)
+        qsk_internal_sync_generated_target_folder("${SUBDIR}")
+    endforeach()
+endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,3 +21,5 @@ if( BUILD_QML_EXPORT )
     add_subdirectory(glabels)
     add_subdirectory(messageboxQml)
 endif()
+
+qsk_internal_sync_generated_target_folder(${CMAKE_CURRENT_LIST_DIR})

--- a/playground/CMakeLists.txt
+++ b/playground/CMakeLists.txt
@@ -29,3 +29,5 @@ endif()
 if(TARGET Qt::QuickWidgets)
     add_subdirectory(grids)
 endif()
+
+qsk_internal_sync_generated_target_folder(${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
The generated Qt `*_qmlimportscan` targets clutter the IDE and should therefore be either put next to their base target's folder or grouped / hidden aways in a collective folder.

Before

![image](https://user-images.githubusercontent.com/6728289/230919931-a9719bf1-7e52-47d3-a0f5-d8f133527e4e.png)

After

![image](https://user-images.githubusercontent.com/6728289/230920017-55f30608-5372-46b1-b7fe-e85468f3c8f5.png)
