### PR TITLE
virtual keyboard: Fix out of bounds access

### DIFF
--- a/src/inputpanel/QskVirtualKeyboard.cpp
+++ b/src/inputpanel/QskVirtualKeyboard.cpp
@@ -434,9 +434,11 @@ void QskVirtualKeyboard::updateKeyCodes()
     m_data->keyCodes = {};
     m_data->keyCodes.reserve( rowCount() * columnCount() );
 
-    for ( int mode = 0; mode < ModeCount; mode++ )
+    const auto layout = *m_data->currentLayout;
+
+    for ( int mode = 0; mode < layout.size(); mode++ )
     {
-        const auto& page = ( *m_data->currentLayout )[ mode ];
+        const auto& page = layout[ mode ];
 
         for ( int i = 0; i < page.size(); i++ )
         {


### PR DESCRIPTION
The user can modify the keyboard rows and cols, so we should not rely on hardcoded values.