### PR TITLE
CI: Kill tasks forcefully on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -418,7 +418,7 @@ jobs:
       - name: Smoke Test Cleanup ( QSkinny ) on Windows
         if: startsWith(matrix.config.name, 'Windows')
         run: |
-          taskkill /IM iotdashboard.exe /T
+          taskkill /IM iotdashboard.exe /T /F
 
       - name: Smoke Test Cleanup ( QSkinny ) on MacOS
         if: startsWith(matrix.config.name, 'macOS')


### PR DESCRIPTION
Otherwise we get the following error:

ERROR: The process with PID 5192 (child process of PID 1372) could not be terminated.
Reason: This process can only be terminated forcefully (with /F option).