### PR TITLE
keyboard: Differentiate between pressed and clicked

### DIFF
--- a/src/inputpanel/QskVirtualKeyboard.cpp
+++ b/src/inputpanel/QskVirtualKeyboard.cpp
@@ -383,6 +383,9 @@ void QskVirtualKeyboard::ensureButtons()
                 connect( button, &QskPushButton::pressed,
                     this, &QskVirtualKeyboard::buttonPressed );
 
+                connect( button, &QskPushButton::clicked,
+                    this, &QskVirtualKeyboard::buttonClicked );
+
                 m_data->keyButtons += button;
             }
         }
@@ -398,8 +401,28 @@ void QskVirtualKeyboard::ensureButtons()
 void QskVirtualKeyboard::buttonPressed()
 {
     const auto button = static_cast< const Button* >( sender() );
+
     if ( button == nullptr )
+    {
         return;
+    }
+
+    const int key = button->key();
+
+    if( qskIsAutorepeat( key ) )
+    {
+        Q_EMIT keySelected( key );
+    }
+}
+
+void QskVirtualKeyboard::buttonClicked()
+{
+    auto button = static_cast< Button* >( sender() );
+
+    if( button == nullptr )
+    {
+        return;
+    }
 
     const int key = button->key();
 
@@ -428,9 +451,10 @@ void QskVirtualKeyboard::buttonPressed()
 
             break;
         }
+
         default:
         {
-            Q_EMIT keySelected( key );
+            break;
         }
     }
 }

--- a/src/inputpanel/QskVirtualKeyboard.h
+++ b/src/inputpanel/QskVirtualKeyboard.h
@@ -107,6 +107,8 @@ class QSK_EXPORT QskVirtualKeyboard : public QskBox
   private:
     void ensureButtons();
     void buttonPressed();
+    void buttonClicked();
+
     void updateKeyCodes();
     QskPushButton::Emphasis emphasisForType( KeyType );
 


### PR DESCRIPTION
For pressed, we want to make use of the auto repeat feature, in contrast to the clicked case.