### PR TITLE
subcontrol layout engine: Allow for laying out more than 2 elements

### DIFF
--- a/src/layouts/QskSubcontrolLayoutEngine.cpp
+++ b/src/layouts/QskSubcontrolLayoutEngine.cpp
@@ -345,31 +345,8 @@ void QskSubcontrolLayoutEngine::setGraphicTextElements( const QskSkinnable* skin
         having to deal with the details of the layout classes.
      */
 
-    GraphicElement* graphicElement = nullptr;
-    if ( !graphicSize.isEmpty() && ( graphicSubControl != QskAspect::NoSubcontrol ) )
-    {
-        graphicElement = dynamic_cast< GraphicElement* >( element( graphicSubControl ) );
-        if ( graphicElement == nullptr )
-        {
-            graphicElement = new GraphicElement( skinnable, graphicSubControl );
-            m_data->elements.prepend( graphicElement );
-        }
-
-        graphicElement->setSourceSize( graphicSize );
-    }
-
-    TextElement* textElement = nullptr;
-    if ( !text.isEmpty() && ( textSubcontrol != QskAspect::NoSubcontrol ) )
-    {
-        textElement = dynamic_cast< TextElement* >( element( textSubcontrol ) );
-        if ( textElement == nullptr )
-        {
-            textElement = new TextElement( skinnable, textSubcontrol );
-            m_data->elements.append( textElement );
-        }
-
-        textElement->setText( text );
-    }
+    auto graphicElement = appendGraphicElement( skinnable, graphicSubControl, graphicSize );
+    auto textElement = appendTextElement( skinnable, textSubcontrol, text );
 
     /*
         Now the difficult part: setting up size policies and the preferred size.
@@ -417,6 +394,46 @@ void QskSubcontrolLayoutEngine::setGraphicTextElements( const QskSkinnable* skin
 
         graphicElement->setPreferredSize( size );
     }
+}
+
+QskSubcontrolLayoutEngine::GraphicElement* QskSubcontrolLayoutEngine::appendGraphicElement( const QskSkinnable* skinnable,
+    QskAspect::Subcontrol graphicSubcontrol, const QSizeF& graphicSize )
+{
+    GraphicElement* graphicElement = nullptr;
+
+    if ( !graphicSize.isEmpty() && ( graphicSubcontrol != QskAspect::NoSubcontrol ) )
+    {
+        graphicElement = dynamic_cast< GraphicElement* >( element( graphicSubcontrol ) );
+        if ( graphicElement == nullptr )
+        {
+            graphicElement = new GraphicElement( skinnable, graphicSubcontrol );
+            m_data->elements.prepend( graphicElement );
+        }
+
+        graphicElement->setSourceSize( graphicSize );
+    }
+
+    return graphicElement;
+}
+
+QskSubcontrolLayoutEngine::TextElement* QskSubcontrolLayoutEngine::appendTextElement( const QskSkinnable* skinnable,
+    QskAspect::Subcontrol textSubcontrol, const QString& text )
+{
+    TextElement* textElement = nullptr;
+
+    if ( !text.isEmpty() && ( textSubcontrol != QskAspect::NoSubcontrol ) )
+    {
+        textElement = dynamic_cast< TextElement* >( element( textSubcontrol ) );
+        if ( textElement == nullptr )
+        {
+            textElement = new TextElement( skinnable, textSubcontrol );
+            m_data->elements.append( textElement );
+        }
+
+        textElement->setText( text );
+    }
+
+    return textElement;
 }
 
 void QskSubcontrolLayoutEngine::setFixedContent(

--- a/src/layouts/QskSubcontrolLayoutEngine.h
+++ b/src/layouts/QskSubcontrolLayoutEngine.h
@@ -127,6 +127,9 @@ class QskSubcontrolLayoutEngine : public QskLayoutEngine2D
         QskAspect::Subcontrol, const QString& text,
         QskAspect::Subcontrol, const QSizeF& graphicSize );
 
+    GraphicElement* appendGraphicElement( const QskSkinnable*, QskAspect::Subcontrol, const QSizeF& );
+    TextElement* appendTextElement( const QskSkinnable*, QskAspect::Subcontrol, const QString& );
+
     void setFixedContent( QskAspect::Subcontrol, Qt::Orientation, Qt::Alignment );
 
     QRectF subControlRect( QskAspect::Subcontrol ) const;


### PR DESCRIPTION
We have a use case internally where we have a segmented bar with an icon, a text and a smaller label text.

I am not sure whether this goes in the right direction, feel free to let me know.

In any case I guess it would be good for the subcontrol layout engine to be able to lay out more than 2 elements...