### PR TITLE
Fluent2 improvements

### DIFF
--- a/skins/fluent2/QskFluent2Skin.cpp
+++ b/skins/fluent2/QskFluent2Skin.cpp
@@ -725,6 +725,7 @@ void Editor::setupMenuColors(
     setShadowColor( Q::Panel, theme.shadow.flyout.color );
 
     setGradient( Q::Segment | Q::Hovered, pal.fillColor.subtle.secondary );
+    setGradient( Q::Segment | Q::Selected | Q::Pressed, pal.fillColor.subtle.tertiary );
 
     setGradient( Q::Segment | Q::Selected, pal.fillColor.subtle.secondary );
 
@@ -739,9 +740,14 @@ void Editor::setupMenuColors(
     setBoxBorderColors( Q::Segment | Q::Selected,
         QskGradient( { { 0.25, c1 }, { 0.25, c2 }, { 0.75, c2 }, { 0.75, c1 } } ) );
 
+    setBoxBorderColors( Q::Segment | Q::Selected | Q::Pressed,
+        QskGradient( { { 0.33, c1 }, { 0.33, c2 }, { 0.67, c2 }, { 0.67, c1 } } ) );
+
     setColor( Q::Text, pal.fillColor.text.primary );
+    setColor( Q::Text | Q::Selected | Q::Pressed, pal.fillColor.text.secondary );
 
     setGraphicRole( Q::Icon, QskFluent2Skin::GraphicRoleFillColorTextPrimary );
+    setGraphicRole( Q::Icon | Q::Selected | Q::Pressed, QskFluent2Skin::GraphicRoleFillColorTextSecondary );
 }
 
 void Editor::setupPageIndicatorMetrics()

--- a/skins/fluent2/QskFluent2Skin.cpp
+++ b/skins/fluent2/QskFluent2Skin.cpp
@@ -514,7 +514,7 @@ void Editor::setupComboBoxColors(
 
     const auto& pal = theme.palette;
 
-    for ( const auto state : { QskAspect::NoState, Q::Hovered, Q::Focused, Q::Disabled } )
+    for ( const auto state : { QskAspect::NoState, Q::Hovered, Q::Focused, Q::Pressed, Q::Disabled } )
     {
         QRgb panelColor, borderColor1, borderColor2, textColor;
 
@@ -535,11 +535,17 @@ void Editor::setupComboBoxColors(
         }
         else if ( state == Q::Focused )
         {
-
             panelColor = pal.fillColor.control.inputActive;
             borderColor1 = pal.elevation.textControl.border[0];
             borderColor2 = pal.fillColor.accent.defaultColor;
             textColor = pal.fillColor.text.primary;
+        }
+        else if ( state == Q::Pressed )
+        {
+            panelColor = pal.fillColor.control.inputActive;
+            borderColor1 = pal.elevation.textControl.border[0];
+            borderColor2 = pal.fillColor.accent.defaultColor;
+            textColor = pal.fillColor.text.secondary;
         }
         else if ( state == Q::Disabled )
         {
@@ -564,6 +570,11 @@ void Editor::setupComboBoxColors(
         {
             setGraphicRole( icon, W::GraphicRoleFillColorTextDisabled );
             setGraphicRole( indicator, W::GraphicRoleFillColorTextDisabled );
+        }
+        else if( state == Q::Pressed )
+        {
+            setGraphicRole( icon, W::GraphicRoleFillColorTextSecondary );
+            setGraphicRole( indicator, W::GraphicRoleFillColorTextSecondary );
         }
         else
         {

--- a/skins/fluent2/QskFluent2Skin.cpp
+++ b/skins/fluent2/QskFluent2Skin.cpp
@@ -724,6 +724,8 @@ void Editor::setupMenuColors(
     setGradient( Q::Panel, pal.background.flyout.defaultColor );
     setShadowColor( Q::Panel, theme.shadow.flyout.color );
 
+    setGradient( Q::Segment | Q::Hovered, pal.fillColor.subtle.secondary );
+
     setGradient( Q::Segment | Q::Selected, pal.fillColor.subtle.secondary );
 
     /*
@@ -734,7 +736,7 @@ void Editor::setupMenuColors(
     const auto c1 = pal.fillColor.subtle.secondary;
     const auto c2 = pal.fillColor.accent.defaultColor;
 
-    setBoxBorderColors( Q::Segment | Q::Selected, 
+    setBoxBorderColors( Q::Segment | Q::Selected,
         QskGradient( { { 0.25, c1 }, { 0.25, c2 }, { 0.75, c2 }, { 0.75, c1 } } ) );
 
     setColor( Q::Text, pal.fillColor.text.primary );

--- a/skins/material3/QskMaterial3Skin.cpp
+++ b/skins/material3/QskMaterial3Skin.cpp
@@ -361,6 +361,8 @@ void Editor::setupMenu()
     setGradient( Q::Segment | Q::Selected, m_pal.primary12 );
     const auto hoverSelectedColor = flattenedColor( m_pal.onSurface, m_pal.primary12, m_pal.hoverOpacity );
     setGradient( Q::Segment | Q::Selected | Q::Hovered, hoverSelectedColor );
+    const auto pressedSelectedColor = flattenedColor( m_pal.onSurface, m_pal.primary12, m_pal.pressedOpacity );
+    setGradient( Q::Segment | Q::Pressed | Q::Selected, pressedSelectedColor );
 
     setPadding( Q::Icon, 7_dp );
     setStrutSize( Q::Icon, 24_dp, 24_dp );

--- a/skins/material3/QskMaterial3Skin.cpp
+++ b/skins/material3/QskMaterial3Skin.cpp
@@ -340,8 +340,8 @@ void Editor::setupMenu()
 
     // The color here is primary with an opacity of 8% - we blend that
     // with the background, because we don't want the menu to have transparency:
-    const auto panel = flattenedColor( m_pal.primary, m_pal.background, 0.08 );
-    setGradient( Q::Panel, panel );
+    const auto panelColor = flattenedColor( m_pal.primary, m_pal.background, 0.08 );
+    setGradient( Q::Panel, panelColor );
 
     setShadowMetrics( Q::Panel, m_pal.elevation2 );
     setShadowColor( Q::Panel, m_pal.shadow );
@@ -355,7 +355,12 @@ void Editor::setupMenu()
     setSpacing( Q::Segment, 5_dp );
     setGradient( Q::Segment, Qt::transparent );
 
-    setGradient( Q::Cursor, m_pal.primary12 );
+    const auto hoverColor = flattenedColor( m_pal.onSurface, panelColor, m_pal.hoverOpacity );
+    setGradient( Q::Segment | Q::Hovered, hoverColor );
+
+    setGradient( Q::Segment | Q::Selected, m_pal.primary12 );
+    const auto hoverSelectedColor = flattenedColor( m_pal.onSurface, m_pal.primary12, m_pal.hoverOpacity );
+    setGradient( Q::Segment | Q::Selected | Q::Hovered, hoverSelectedColor );
 
     setPadding( Q::Icon, 7_dp );
     setStrutSize( Q::Icon, 24_dp, 24_dp );

--- a/skins/material3/QskMaterial3Skin.cpp
+++ b/skins/material3/QskMaterial3Skin.cpp
@@ -278,6 +278,10 @@ void Editor::setupComboBox()
         m_pal.surfaceVariant, m_pal.focusOpacity );
     setGradient( Q::Panel | Q::Focused, focusColor );
 
+    const auto pressedColor = flattenedColor( m_pal.onSurfaceVariant,
+        m_pal.surfaceVariant, m_pal.pressedOpacity );
+    setGradient( Q::Panel | Q::Pressed, pressedColor );
+
     const auto activeColor = flattenedColor( m_pal.onSurfaceVariant,
         m_pal.surfaceVariant, m_pal.pressedOpacity );
     setGradient( Q::Panel | Q::PopupOpen, activeColor );

--- a/src/controls/QskComboBox.cpp
+++ b/src/controls/QskComboBox.cpp
@@ -18,7 +18,8 @@ QSK_SUBCONTROL( QskComboBox, Icon )
 QSK_SUBCONTROL( QskComboBox, Text )
 QSK_SUBCONTROL( QskComboBox, StatusIndicator )
 
-QSK_SYSTEM_STATE( QskComboBox, PopupOpen, QskAspect::FirstSystemState << 1 )
+QSK_SYSTEM_STATE( QskComboBox, Pressed, QskAspect::FirstSystemState << 1 )
+QSK_SYSTEM_STATE( QskComboBox, PopupOpen, QskAspect::FirstSystemState << 2 )
 
 static inline void qskTraverseOptions( QskComboBox* comboBox, int steps )
 {
@@ -87,6 +88,25 @@ QskComboBox::QskComboBox( QQuickItem* parent )
 
 QskComboBox::~QskComboBox()
 {
+}
+
+bool QskComboBox::isPressed() const
+{
+    return hasSkinState( Pressed );
+}
+
+void QskComboBox::setPressed( bool on )
+{
+    if ( on == isPressed() )
+        return;
+
+    setSkinStateFlag( Pressed, on );
+    Q_EMIT pressedChanged( on );
+
+    if ( on )
+        Q_EMIT pressed();
+    else
+        Q_EMIT released();
 }
 
 void QskComboBox::setPopupOpen( bool on )
@@ -246,11 +266,13 @@ void QskComboBox::closePopup()
 
 void QskComboBox::mousePressEvent( QMouseEvent* )
 {
+    setPressed( true );
     setPopupOpen( true );
 }
 
 void QskComboBox::mouseReleaseEvent( QMouseEvent* )
 {
+    setPressed( false );
 }
 
 void QskComboBox::keyPressEvent( QKeyEvent* event )
@@ -259,6 +281,7 @@ void QskComboBox::keyPressEvent( QKeyEvent* event )
     {
         if ( !event->isAutoRepeat() )
         {
+            setPressed( true );
             setPopupOpen( true );
             return;
         }
@@ -270,6 +293,7 @@ void QskComboBox::keyPressEvent( QKeyEvent* event )
         case Qt::Key_F4:
         {
             // QComboBox does this ???
+            setPressed( true );
             setPopupOpen( true );
             return;
         }

--- a/src/controls/QskComboBox.h
+++ b/src/controls/QskComboBox.h
@@ -34,15 +34,21 @@ class QSK_EXPORT QskComboBox : public QskControl
     Q_PROPERTY( int indexInPopup READ indexInPopup
         NOTIFY indexInPopupChanged )
 
+    Q_PROPERTY( bool pressed READ isPressed
+        WRITE setPressed NOTIFY pressedChanged FINAL )
+
     using Inherited = QskControl;
 
   public:
     QSK_SUBCONTROLS( Panel, Icon, Text, StatusIndicator )
-    QSK_STATES( PopupOpen )
+    QSK_STATES( Pressed, PopupOpen )
 
     QskComboBox( QQuickItem* parent = nullptr );
 
     ~QskComboBox() override;
+
+    void setPressed( bool on );
+    bool isPressed() const;
 
     void setPopupOpen( bool );
     bool isPopupOpen() const;
@@ -78,6 +84,10 @@ class QSK_EXPORT QskComboBox : public QskControl
     void setCurrentIndex( int );
 
   Q_SIGNALS:
+    void pressed();
+    void released();
+    void pressedChanged( bool );
+
     void currentIndexChanged( int );
     void indexInPopupChanged( int );
 

--- a/src/controls/QskMenu.cpp
+++ b/src/controls/QskMenu.cpp
@@ -27,6 +27,7 @@ QSK_SUBCONTROL( QskMenu, Icon )
 QSK_SUBCONTROL( QskMenu, Separator )
 
 QSK_SYSTEM_STATE( QskMenu, Selected, QskAspect::FirstSystemState << 2 )
+QSK_SYSTEM_STATE( QskMenu, Pressed, QskAspect::FirstSystemState << 3 )
 
 static inline int qskActionIndex( const QVector< int >& actions, int index )
 {
@@ -309,7 +310,7 @@ void QskMenu::keyPressEvent( QKeyEvent* event )
 
 void QskMenu::keyReleaseEvent( QKeyEvent* )
 {
-    if( m_data->isPressed )
+    if( isPressed() )
     {
         m_data->isPressed = false;
 
@@ -416,7 +417,7 @@ void QskMenu::mouseReleaseEvent( QMouseEvent* event )
 {
     if ( event->button() == Qt::LeftButton )
     {
-        if( m_data->isPressed )
+        if( isPressed() )
         {
             m_data->isPressed = false;
 
@@ -479,6 +480,11 @@ int QskMenu::indexAtPosition( const QPointF& pos ) const
         this, contentsRect(), QskMenu::Segment, pos );
 
     return m_data->actions.value( index, -1 );
+}
+
+bool QskMenu::isPressed() const
+{
+    return m_data->isPressed;
 }
 
 void QskMenu::trigger( int index )

--- a/src/controls/QskMenu.cpp
+++ b/src/controls/QskMenu.cpp
@@ -72,6 +72,8 @@ QskMenu::QskMenu( QQuickItem* parent )
 
     connect( this, &QskMenu::opened, this,
         [this]() { m_data->triggeredIndex = -1; } );
+
+    setAcceptHoverEvents( true );
 }
 
 QskMenu::~QskMenu()
@@ -317,6 +319,30 @@ void QskMenu::keyReleaseEvent( QKeyEvent* )
             trigger( m_data->currentIndex );
         }
     }
+}
+
+void QskMenu::hoverEnterEvent( QHoverEvent* event )
+{
+    using A = QskAspect;
+
+    setSkinHint( Segment | Hovered | A::Metric | A::Position, qskHoverPosition( event ) );
+    update();
+}
+
+void QskMenu::hoverMoveEvent( QHoverEvent* event )
+{
+    using A = QskAspect;
+
+    setSkinHint( Segment | Hovered | A::Metric | A::Position, qskHoverPosition( event ) );
+    update();
+}
+
+void QskMenu::hoverLeaveEvent( QHoverEvent* )
+{
+    using A = QskAspect;
+
+    setSkinHint( Segment | Hovered | A::Metric | A::Position, QPointF() );
+    update();
 }
 
 #ifndef QT_NO_WHEELEVENT

--- a/src/controls/QskMenu.h
+++ b/src/controls/QskMenu.h
@@ -38,7 +38,7 @@ class QSK_EXPORT QskMenu : public QskPopup
 
   public:
     QSK_SUBCONTROLS( Overlay, Panel, Segment, Cursor, Text, Icon, Separator )
-    QSK_STATES( Selected )
+    QSK_STATES( Selected, Pressed )
 
     QskMenu( QQuickItem* parentItem = nullptr );
     ~QskMenu() override;
@@ -78,6 +78,8 @@ class QSK_EXPORT QskMenu : public QskPopup
 
     QRectF cellRect( int index ) const;
     int indexAtPosition( const QPointF& ) const;
+
+    bool isPressed() const;
 
     Q_INVOKABLE int exec();
 

--- a/src/controls/QskMenu.h
+++ b/src/controls/QskMenu.h
@@ -68,6 +68,7 @@ class QSK_EXPORT QskMenu : public QskPopup
     QVector< int > actions() const;
 
     int currentIndex() const;
+
     QString currentText() const;
 
     int triggeredIndex() const;
@@ -96,6 +97,10 @@ class QSK_EXPORT QskMenu : public QskPopup
   protected:
     void keyPressEvent( QKeyEvent* ) override;
     void keyReleaseEvent( QKeyEvent* ) override;
+
+    void hoverEnterEvent( QHoverEvent* ) override;
+    void hoverMoveEvent( QHoverEvent* ) override;
+    void hoverLeaveEvent( QHoverEvent* ) override;
 
 #ifndef QT_NO_WHEELEVENT
     void wheelEvent( QWheelEvent* ) override;

--- a/src/controls/QskMenuSkinlet.cpp
+++ b/src/controls/QskMenuSkinlet.cpp
@@ -385,6 +385,7 @@ QskAspect::States QskMenuSkinlet::sampleStates(
     const QskSkinnable* skinnable, QskAspect::Subcontrol subControl, int index ) const
 {
     using Q = QskMenu;
+    using A = QskAspect;
 
     auto states = Inherited::sampleStates( skinnable, subControl, index );
 
@@ -394,6 +395,17 @@ QskAspect::States QskMenuSkinlet::sampleStates(
 
         if ( menu->currentIndex() == menu->actions()[ index ] )
             states |= QskMenu::Selected;
+
+        const auto cursorPos = menu->effectiveSkinHint( Q::Segment | Q::Hovered | A::Metric | A::Position ).toPointF();
+
+        if( !cursorPos.isNull() && menu->indexAtPosition( cursorPos ) == index )
+        {
+            states |= Q::Hovered;
+        }
+        else
+        {
+            states &= ~Q::Hovered;
+        }
     }
 
     return states;

--- a/src/controls/QskMenuSkinlet.cpp
+++ b/src/controls/QskMenuSkinlet.cpp
@@ -394,7 +394,18 @@ QskAspect::States QskMenuSkinlet::sampleStates(
         const auto menu = static_cast< const QskMenu* >( skinnable );
 
         if ( menu->currentIndex() == menu->actions()[ index ] )
-            states |= QskMenu::Selected;
+        {
+            states |= Q::Selected;
+
+            if( menu->isPressed() )
+            {
+                states |= Q::Pressed;
+            }
+            else
+            {
+                states &= ~Q::Pressed;
+            }
+        }
 
         const auto cursorPos = menu->effectiveSkinHint( Q::Segment | Q::Hovered | A::Metric | A::Position ).toPointF();
 


### PR DESCRIPTION
menu: support pressed and hovered, combo box: support pressed

@uwerat : I started this PR as Fluent2 improvements, but actually they affect both F2 and M3. I can also rebase them on your master; but I guess since you are refactoring the F2 skin, these changes here can go on top of your refactorings...