### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -108,6 +108,6 @@ SpacesInSquareBrackets: true
 Standard:        Cpp11
 TabWidth:        4
 UseTab:          Never
-UseCRLF:         True
+UseCRLF:         true
 ...
 

--- a/.clang-format
+++ b/.clang-format
@@ -108,6 +108,6 @@ SpacesInSquareBrackets: true
 Standard:        Cpp11
 TabWidth:        4
 UseTab:          Never
-UseCRLF:         Always
+UseCRLF:         True
 ...
 


### PR DESCRIPTION
`UseCRLF` is a boolean and therefore causes problems when using clang-format

see: https://clang.llvm.org/docs/ClangFormatStyleOptions.html#usecrlf

Since the option itself is deprecated we could also switch to clang format 16's `LineEnding` = `LF` or `CRLF`

see: https://clang.llvm.org/docs/ClangFormatStyleOptions.html#lineending