### PR TITLE
Fluent2: Don't flatten border colors to a color without alpha value

### DIFF
--- a/skins/fluent2/QskFluent2Skin.cpp
+++ b/skins/fluent2/QskFluent2Skin.cpp
@@ -139,18 +139,11 @@ namespace
         return qRgba( value, value, value, qRound( opacity * 255 ) );
     }
 
-    inline constexpr QRgb rgbFlattened( QRgb foreground, QRgb background )
+    inline QRgb rgbFlattened( QRgb foreground, QRgb background )
     {
-        //Q_ASSERT( qAlpha( background ) == 255 );
+        const auto alpha = qAlpha( foreground ) / 255.0;
 
-        const auto r2 = qAlpha( foreground ) / 255.0;
-        const auto r1 = 1.0 - r2;
-
-        const auto r = qRound( r1 * qRed( background ) + r2 * qRed( foreground ) );
-        const auto g = qRound( r1 * qGreen( background ) + r2 * qGreen( foreground ) );
-        const auto b = qRound( r1 * qBlue( background ) + r2 * qBlue( foreground ) );
-
-        return qRgb( r, g, b );
+        return QskRgb::interpolated( background, foreground, alpha );
     }
 
     inline constexpr QRgb rgbSolid( QRgb foreground, QRgb background )


### PR DESCRIPTION
... or something along those lines.

before:

![Screenshot from 2023-10-20 14-20-09](https://github.com/uwerat/qskinny/assets/1749504/e14f9a69-082e-4a61-965b-3987708b6ffc)

after:

![Screenshot from 2023-10-20 14-19-45](https://github.com/uwerat/qskinny/assets/1749504/e1cb3772-5284-490a-b4c4-12639c2d3fc2)
