### PR TITLE
Don't use CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ project(QSkinny
     HOMEPAGE_URL "https://github.com/uwerat/qskinny"
     VERSION 0.8.0)
 
+set(QSK_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
+
 qsk_setup_options()
 
 include(GNUInstallDirs)

--- a/inputcontext/CMakeLists.txt
+++ b/inputcontext/CMakeLists.txt
@@ -19,8 +19,8 @@ if(ENABLE_PINYIN)
     qsk_setup_Pinyin()
 
     list(APPEND SOURCES
-        ${CMAKE_SOURCE_DIR}/src/inputpanel/QskPinyinTextPredictor.h
-        ${CMAKE_SOURCE_DIR}/src/inputpanel/QskPinyinTextPredictor.cpp
+        ${QSK_SOURCE_DIR}/src/inputpanel/QskPinyinTextPredictor.h
+        ${QSK_SOURCE_DIR}/src/inputpanel/QskPinyinTextPredictor.cpp
     )
 endif()
 
@@ -28,8 +28,8 @@ if(ENABLE_HUNSPELL)
     qsk_setup_Hunspell()
 
     list(APPEND SOURCES
-        ${CMAKE_SOURCE_DIR}/src/inputpanel/QskHunspellTextPredictor.h
-        ${CMAKE_SOURCE_DIR}/src/inputpanel/QskHunspellTextPredictor.cpp
+        ${QSK_SOURCE_DIR}/src/inputpanel/QskHunspellTextPredictor.h
+        ${QSK_SOURCE_DIR}/src/inputpanel/QskHunspellTextPredictor.cpp
     )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -492,7 +492,7 @@ if(ENABLE_PINYIN)
     target_link_libraries(${target} PRIVATE pinyin Fcitx5::Utils)
 
     target_include_directories(${target}
-        PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/inputcontext>)
+        PUBLIC $<BUILD_INTERFACE:${QSK_SOURCE_DIR}/inputcontext>)
 endif()
 
 set_target_properties(${target} PROPERTIES FOLDER libs)

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -31,7 +31,7 @@ target_compile_definitions(${target}
 target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 if(ENABLE_ENSURE_SKINS)
-    target_include_directories(${target} PRIVATE ${CMAKE_SOURCE_DIR}/skins)
+    target_include_directories(${target} PRIVATE ${QSK_SOURCE_DIR}/skins)
     target_compile_definitions(${target} PRIVATE ENSURE_SKINS)
     target_link_libraries(${target} PRIVATE squiekskin material3skin fluent2skin)
 endif()

--- a/tools/svg2qvg/CMakeLists.txt
+++ b/tools/svg2qvg/CMakeLists.txt
@@ -28,8 +28,8 @@ if(BUILD_SVG2QVG_STANDALONE)
 
     target_include_directories(${target}
         PRIVATE
-            ${CMAKE_SOURCE_DIR}/src/common
-            ${CMAKE_SOURCE_DIR}/src/graphic)
+            ${QSK_SOURCE_DIR}/src/common
+            ${QSK_SOURCE_DIR}/src/graphic)
 
     target_compile_definitions(${target} PRIVATE QSK_STANDALONE)
     target_link_libraries(${target} PRIVATE Qt::Gui Qt::GuiPrivate)


### PR DESCRIPTION
# Problem 

Consider the following folder structure:

- myproject
  - qskinny ( e.g. git submodule or deep copy of qskinny )
    - qskinny stuff ...
    - CMakeLists.txt <- `QSK_SOURCE_DIR` 👍  
  - main.cpp
  - myskinnable.h
  - myskinnable.cpp
  - CMakeLists.txt <- `CMAKE_SOURCE_DIR` 👎  

If the user now builds his project alongside with qskinny in its build tree the `CMAKE_SOURCE_DIR` will point to `myproject` and not to `myproject/qskinny`

# Solution

Don't use `CMAKE_SOURCE_DIR`, rather use a `QSK_SOURCE_DIR` which points to QSkinny's topmost CMakeLists.txt directory