### PR TITLE
Qsk cmake find package

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -431,22 +431,22 @@ jobs:
           killall iotdashboard
           killall Xvfb
 
-      #- name: Configure ( CMake Integration Test )
-      #  shell: bash
-      #  run: |
-      #    mkdir qskinny_build_test
-      #    cmake \
-      #      -S qskinny_source/examples/iotdashboard_smoketest \
-      #      -B qskinny_build_test \
-      #      -G "${{ matrix.config.generators }}" \
-      #      -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
-      #      -DCMAKE_PREFIX_PATH:PATH="${{ matrix.config.cmake.qtprefixpath }}" \
-      #      -D${{ matrix.config.cmake.qtdirkey }}:PATH="${{ matrix.config.cmake.qtdirvalue }}" \
-      #      -DQSkinny_DIR:PATH=$GITHUB_WORKSPACE/qskinny_install/lib/cmake/QSkinny
-#
-      #- name: Build ( CMake Integration Test )
-      #  shell: bash
-      #  run: cmake --build qskinny_build_test --config ${{ matrix.config.build_type }}
+      - name: Configure ( CMake Integration Test )
+        shell: bash
+        run: |
+          mkdir qskinny_build_test
+          cmake \
+            -S qskinny_source/examples/iotdashboard_smoketest \
+            -B qskinny_build_test \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -DCMAKE_PREFIX_PATH:PATH="${{ matrix.config.cmake.qtprefixpath }}" \
+            -D${{ matrix.config.cmake.qtdirkey }}:PATH="${{ matrix.config.cmake.qtdirvalue }}" \
+            -DQSkinny_DIR:PATH=$GITHUB_WORKSPACE/qskinny_install/lib/cmake/QSkinny
+
+      - name: Build ( CMake Integration Test )
+        shell: bash
+        run: cmake --build qskinny_build_test --config ${{ matrix.config.build_type }}
 
       # - name: Pack
       #   shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ macro(qsk_setup_build)
 endmacro()
 
 macro(qsk_setup_install)
-    # we have to provide and install a QSkinnyConfig.cmake
-    # TODO ...
+    set(QSK_INSTALL_HEADERS include)
+    set(QSK_INSTALL_LIBS lib)
 endmacro()
 
 ############################################################################
@@ -123,7 +123,7 @@ endif()
 set(PACKAGE_NAME      ${PROJECT_NAME})
 set(PACKAGE_VERSION   ${CMAKE_PROJECT_VERSION})
 set(PACKAGE_NAMESPACE Qsk)
-set(PACKAGE_LOCATION  lib/cmake/${PROJECT_NAME})
+set(PACKAGE_LOCATION  ${QSK_INSTALL_LIBS}/cmake/${PROJECT_NAME})
 
 install(TARGETS qskinny EXPORT ${PACKAGE_NAME}Targets
     LIBRARY DESTINATION       ${QSK_INSTALL_LIBS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,3 +118,48 @@ endif()
 if(BUILD_PLAYGROUND)
     add_subdirectory(playground)
 endif()
+
+# packaging
+set(PACKAGE_NAME      ${PROJECT_NAME})
+set(PACKAGE_VERSION   ${CMAKE_PROJECT_VERSION})
+set(PACKAGE_NAMESPACE Qsk)
+set(PACKAGE_LOCATION  lib/cmake/${PROJECT_NAME})
+
+install(TARGETS qskinny EXPORT ${PACKAGE_NAME}Targets
+    LIBRARY DESTINATION       ${QSK_INSTALL_LIBS}
+    ARCHIVE DESTINATION       ${QSK_INSTALL_LIBS}
+    RUNTIME DESTINATION       ${QSK_INSTALL_LIBS}
+    INCLUDES DESTINATION      ${QSK_INSTALL_HEADERS}
+    PUBLIC_HEADER DESTINATION ${QSK_INSTALL_HEADERS})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}/${PACKAGE_NAME}ConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+export(EXPORT ${PACKAGE_NAME}Targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}/${PACKAGE_NAME}Targets.cmake
+    NAMESPACE ${PACKAGE_NAMESPACE}::)
+
+configure_file(cmake/${PACKAGE_NAME}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}/${PACKAGE_NAME}Config.cmake
+    COPYONLY)
+
+install(EXPORT ${PACKAGE_NAME}Targets
+    FILE
+        ${PACKAGE_NAME}Targets.cmake
+    NAMESPACE
+        ${PACKAGE_NAMESPACE}::
+    DESTINATION
+        ${PACKAGE_LOCATION})
+
+install(
+    FILES
+        cmake/${PACKAGE_NAME}Config.cmake
+        cmake/QskTools.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}/${PACKAGE_NAME}ConfigVersion.cmake
+    DESTINATION
+        ${PACKAGE_LOCATION}
+    COMPONENT
+        Devel)

--- a/cmake/QSkinnyConfig.cmake
+++ b/cmake/QSkinnyConfig.cmake
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/QSkinnyTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/QskTools.cmake")

--- a/examples/iotdashboard_smoketest/.gitignore
+++ b/examples/iotdashboard_smoketest/.gitignore
@@ -1,0 +1,2 @@
+build
+iotdashboard

--- a/examples/iotdashboard_smoketest/CMakeLists.txt
+++ b/examples/iotdashboard_smoketest/CMakeLists.txt
@@ -2,23 +2,46 @@ cmake_minimum_required(VERSION 3.18)
 
 project(iotdashboard_smoketest)
 
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC OFF)
+set(CMAKE_GLOBAL_AUTOGEN_TARGET OFF)
+
 find_package(QSkinny REQUIRED)
+
+# TODO we don't delivery the qsk macros
+function(qsk_add_executable target)
+    if(QT_VERSION_MAJOR VERSION_GREATER_EQUAL 6)
+        qt6_add_executable(${ARGV})
+    else()
+        add_executable(${ARGV})
+    endif()
+endfunction()
+
+# TODO we don't delivery the qsk macros
+function(qsk_add_example target)
+    cmake_parse_arguments(PARSE_ARGV 1 arg "MANUAL_FINALIZATION" "" "")
+    add_executable(${target} WIN32 MACOSX_BUNDLE ${arg_UNPARSED_ARGUMENTS} )
+    target_link_libraries(${target} PRIVATE Qsk::qskinny )
+    target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+endfunction()
 
 find_package(Qt6 COMPONENTS Core QUIET)
 if (NOT Qt6_FOUND)
     find_package(Qt5 5.15 REQUIRED COMPONENTS Core Gui OpenGL Quick Svg Widgets)
     find_package(Qt5 5.15 OPTIONAL_COMPONENTS QuickWidgets WebEngine WebEngineCore)
-    message(WARNING "using QSkinny's 'qt_add_executable()'")
+
     function(qt_add_executable)
         add_executable(${ARGV})
     endfunction(qt_add_executable)
-    message(WARNING "using QSkinny's 'qt_add_library()'")
-    function(qt_add_library)
-        add_library(${ARGV})
-    endfunction(qt_add_library)
 else()
     find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL Quick QuickWidgets Svg Widgets)
     find_package(Qt6 OPTIONAL_COMPONENTS QuickWidgets WebEngineCore WebEngineQuick)
 endif()
 
 add_subdirectory(../iotdashboard ${CMAKE_CURRENT_BINARY_DIR}/../iotdashboard)
+
+# TODO we don't delivery the support library
+get_target_property(iotdashboard_COMPILE_DEFINITIONS iotdashboard COMPILE_DEFINITIONS)
+list(FILTER iotdashboard_COMPILE_DEFINITIONS EXCLUDE REGEX [[^USE_SHORTCUTS=1$]])
+set_property(TARGET iotdashboard PROPERTY COMPILE_DEFINITIONS ${iotdashboard_COMPILE_DEFINITIONS})

--- a/examples/iotdashboard_smoketest/CMakeLists.txt
+++ b/examples/iotdashboard_smoketest/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(iotdashboard_smoketest)
+
+find_package(QSkinny REQUIRED)
+
+find_package(Qt6 COMPONENTS Core QUIET)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Gui OpenGL Quick Svg Widgets)
+    find_package(Qt5 5.15 OPTIONAL_COMPONENTS QuickWidgets WebEngine WebEngineCore)
+    message(WARNING "using QSkinny's 'qt_add_executable()'")
+    function(qt_add_executable)
+        add_executable(${ARGV})
+    endfunction(qt_add_executable)
+    message(WARNING "using QSkinny's 'qt_add_library()'")
+    function(qt_add_library)
+        add_library(${ARGV})
+    endfunction(qt_add_library)
+else()
+    find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL Quick QuickWidgets Svg Widgets)
+    find_package(Qt6 OPTIONAL_COMPONENTS QuickWidgets WebEngineCore WebEngineQuick)
+endif()
+
+add_subdirectory(../iotdashboard ${CMAKE_CURRENT_BINARY_DIR}/../iotdashboard)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -483,6 +483,10 @@ target_include_directories(${target} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/layouts>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/nodes>)
 
+target_include_directories(${target}
+    INTERFACE
+        $<INSTALL_INTERFACE:${QSK_INSTALL_HEADERS}>)
+
 target_link_libraries(${target}
     PUBLIC Qt::Core Qt::CorePrivate Qt::Quick Qt::QuickPrivate)
 


### PR DESCRIPTION
Reintegration of QSkinny CMake Find Module generation from: https://github.com/uwerat/qskinny/pull/291
Relates to: https://github.com/uwerat/qskinny/issues/119
Relates to: https://github.com/uwerat/qskinny/pull/351#issuecomment-1865925955

# Usage

```bash
cmake \
            -S <your source director> \
            -B <your build director> \
            -G "<your generator>" \ # optional e.g. "Unix Makefiles"|"Ninja"|...
            -DCMAKE_BUILD_TYPE=<your build type> \ # optional e.g. Release|Debug|RelWithDebInfo|...
            -DCMAKE_PREFIX_PATH:PATH="<your qt prefix path>" \ # add qt's root directory e.g. C:\sdk\Qt\5.15.2\msvc2019_64
            -DQt5_DIR:PATH="<your qt cmake directory>" \ # add Qt*_DIR e.g. C:\sdk\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5
            -DQSkinny_DIR:PATH=<your qskinny install root directory>/lib/cmake/QSkinny
```

> see: https://github.com/uwerat/qskinny/blob/master/.github/workflows/cmake.yml#L434


```cmake
find_package(QSkinny REQUIRED)

add_executable(${target} ...)

target_link_libraries(${target} PRIVATE Qsk::qskinny )
```