### PR TITLE
Bug/Search for Qt6 then Qt5 before building

### DIFF
--- a/cmake/QskFindMacros.cmake
+++ b/cmake/QskFindMacros.cmake
@@ -5,12 +5,11 @@
 
 macro(qsk_setup_Qt)
 
-    # Often users have several Qt installations on their system and
-    # need to be able to explicitly the one to be used. Let's see if
-    # standard cmake features are good enough or if we need to introduce
-    # something sort of additional option. TODO ...
-
-    find_package(QT "5.15" NAMES Qt6 Qt5 REQUIRED COMPONENTS Quick)
+    # Define a package QT, attempt Qt6, if not fallback to Qt5
+    find_package(QT NAMES Qt6 REQUIRED COMPONENTS Quick)
+    if (NOT QT_FOUND)
+        find_package(QT "5.15" NAMES Qt5 REQUIRED COMPONENTS Quick)
+    endif()
 
     if ( QT_FOUND )
 

--- a/cmake/QskFindMacros.cmake
+++ b/cmake/QskFindMacros.cmake
@@ -5,11 +5,15 @@
 
 macro(qsk_setup_Qt)
 
-    # Define a package QT, attempt Qt6, if not fallback to Qt5
-    find_package(QT NAMES Qt6 REQUIRED COMPONENTS Quick)
-    if (NOT QT_FOUND)
-        find_package(QT "5.15" NAMES Qt5 REQUIRED COMPONENTS Quick)
+    # Use QSK_QT_VERSION specified with baseline 5.15
+    # otherwise fallback to latest known supported Qt version gte 5.15
+    # set vars for correct alpha descending sort order and direction (ex. Qt6, Qt5)
+    if ( NOT QSK_QT_VERSION ) # QSK_QT_VERSION=Qt5
+        set(QSK_QT_VERSION Qt6 Qt5)
+        set(CMAKE_FIND_PACKAGE_SORT_ORDER NAME)
+        set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
     endif()
+    find_package(QT "5.15" NAMES ${QSK_QT_VERSION} REQUIRED COMPONENTS Quick)
 
     if ( QT_FOUND )
 


### PR DESCRIPTION
There is a bug with find_package in which the ordering is not respected on Linux:

[Linux Bug](https://gitlab.kitware.com/cmake/cmake/-/issues/23575)

This makes the `qsk_setup_Qt` macro always load Qt5 (as opposed to suggested [practices](https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#supporting-older-qt-5-versions)).

This will check for the Qt6 first then fallback to Qt5 if not found, thus replicating the best practice behavior.

To target a specific version pass `QSK_QT_VERSION` to the cmake build command: 

```sh
$ cmake -DQSK_QT_VERSION=Qt5 ../ && make
```

Documentation to be added in #351 