### PR TITLE
Feature/Cmake Install Optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ install(
     FILES
         ${CMAKE_BINARY_DIR}/_QSkinny/${PACKAGE_NAME}Config.cmake
         ${CMAKE_BINARY_DIR}/_QSkinny/${PACKAGE_NAME}ConfigVersion.cmake
-        ${QSK_CMAKE_DIR}/QskTools.cmake
     DESTINATION
         ${PACKAGE_LOCATION}
     COMPONENT

--- a/cmake/QSkinnyConfig.cmake
+++ b/cmake/QSkinnyConfig.cmake
@@ -1,1 +1,3 @@
 include("${CMAKE_CURRENT_LIST_DIR}/QSkinnyTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/QskTools.cmake" OPTIONAL)
+include("${CMAKE_CURRENT_LIST_DIR}/QmlExportTargets.cmake" OPTIONAL)

--- a/cmake/QskBuildFunctions.cmake
+++ b/cmake/QskBuildFunctions.cmake
@@ -115,11 +115,3 @@ function(qsk_add_shaders target)
         PREFIX "/qskinny/shaders" ${ARGV} OUTPUTS ${outfiles} )
 
 endfunction()
-
-function(qsk_update_package_config_file target)
-
-    file(APPEND
-        ${CMAKE_BINARY_DIR}/_QSkinny/QSkinnyConfig.cmake
-        "include(\"\${CMAKE_CURRENT_LIST_DIR}/${target}.cmake\")\n")
-
-endfunction()

--- a/qmlexport/CMakeLists.txt
+++ b/qmlexport/CMakeLists.txt
@@ -42,5 +42,3 @@ install(EXPORT ${PACKAGE_NAME}Targets
         ${PACKAGE_NAMESPACE}
     DESTINATION
         ${PACKAGE_LOCATION})
-
-qsk_update_package_config_file(${PACKAGE_NAME}Targets)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,10 @@
 if(TARGET Qt::Svg)
     add_subdirectory(svg2qvg)
-    qsk_update_package_config_file(QskTools)
+    install(
+        FILES
+            ${QSK_CMAKE_DIR}/QskTools.cmake
+        DESTINATION
+            ${PACKAGE_LOCATION}
+        COMPONENT
+            Devel)
 endif()


### PR DESCRIPTION
Accomplishes the following from review on #351 

- move QskTools.cmake to optional install directive
- remove qsk_update_package_config_file for OPTIONAL cmake keyword

Outstanding issues:

- QSkinny Namespace - https://github.com/uwerat/qskinny/issues/358
- `QmlExport` headers are installed - https://github.com/uwerat/qskinny/pull/351/files/f4315ce4acb3da64e6786a39830b52566aa94201#r1444773948
- `QSK_QT_VERSION` variable - https://github.com/uwerat/qskinny/pull/351/files/f4315ce4acb3da64e6786a39830b52566aa94201#r1438901244
- `_QSkinny` Cmake build folder needed?
    - https://github.com/uwerat/qskinny/pull/351/files/f4315ce4acb3da64e6786a39830b52566aa94201#r1438891578
    -  https://github.com/uwerat/qskinny/pull/351/files/f4315ce4acb3da64e6786a39830b52566aa94201#r1438892194
