### PR TITLE
Doc/"Adding UI Controls" example does not work

### DIFF
--- a/doc/tutorials/03-writing-your-first-application.asciidoc
+++ b/doc/tutorials/03-writing-your-first-application.asciidoc
@@ -74,14 +74,13 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Quick)
+find_package(Qt5 REQUIRED COMPONENTS Quick)
 find_package(QSkinny REQUIRED)
 
 add_executable(myapp
     src/main.cpp)
 
 target_link_libraries(myapp PRIVATE
-    Qt5::Widgets
     Qt5::Quick
     QSkinny::QSkinny)
 ....
@@ -123,6 +122,7 @@ int main( int argc, char* argv[] )
     QGuiApplication app( argc, argv );
 
     auto* horizontalBox = new QskLinearBox( Qt::Horizontal );
+    horizontalBox->setPanel( true );
     auto* button1 = new QskPushButton( "button 1", horizontalBox );
     auto* button2 = new QskPushButton( "button 2", horizontalBox );
 


### PR DESCRIPTION
In chapter 3 of the docs `Writing your first application`, subsection `Adding UI Controls` the example main code does not work.

Example from docs:
```cpp
#include <QskWindow.h>
#include <QskLinearBox.h>
#include <QskPushButton.h>

#include <QGuiApplication>

int main( int argc, char* argv[] )
{
    QGuiApplication app( argc, argv );

    auto* horizontalBox = new QskLinearBox( Qt::Horizontal );
    auto* button1 = new QskPushButton( "button 1", horizontalBox );
    auto* button2 = new QskPushButton( "button 2", horizontalBox );

    QskWindow window;
    window.addItem( horizontalBox );
    window.show();

    return app.exec();
}
```

This renders an empty window on X11 and on Wayland.

By adding a call to `setPanel( true );` on the `QskLinearBox` the example will render the two buttons.

Is this necessary or is there a clearer simple example to demonstrate a basic QSkinny app?


