### PR TITLE
Bug/CMAKE_PREFIX_PATH for find_package Qt Version

### DIFF
--- a/cmake/QskFindMacros.cmake
+++ b/cmake/QskFindMacros.cmake
@@ -5,15 +5,12 @@
 
 macro(qsk_setup_Qt)
 
-    # Use QSK_QT_VERSION specified with baseline 5.15
-    # otherwise fallback to latest known supported Qt version gte 5.15
-    # set vars for correct alpha descending sort order and direction (ex. Qt6, Qt5)
-    if ( NOT QSK_QT_VERSION ) # QSK_QT_VERSION=Qt5
-        set(QSK_QT_VERSION Qt6 Qt5)
-        set(CMAKE_FIND_PACKAGE_SORT_ORDER NAME)
-        set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
-    endif()
-    find_package(QT "5.15" NAMES ${QSK_QT_VERSION} REQUIRED COMPONENTS Quick)
+    # find_package() sort order and direction bug
+    # where Qt6 is not considered before Qt5
+    # bug link: https://gitlab.kitware.com/cmake/cmake/-/issues/23575
+    set(CMAKE_FIND_PACKAGE_SORT_ORDER NAME)
+    set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+    find_package(QT "5.15" NAMES Qt6 Qt5 REQUIRED COMPONENTS Quick)
 
     if(QT_VERSION_MAJOR VERSION_GREATER_EQUAL 6)
         # we need the qsb tool for Qt6

--- a/doc/tutorials/03-writing-your-first-application.asciidoc
+++ b/doc/tutorials/03-writing-your-first-application.asciidoc
@@ -74,14 +74,13 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Quick)
+find_package(Qt5 REQUIRED COMPONENTS Quick)
 find_package(QSkinny REQUIRED)
 
 add_executable(myapp
     src/main.cpp)
 
 target_link_libraries(myapp PRIVATE
-    Qt5::Widgets
     Qt5::Quick
     QSkinny::QSkinny)
 ....
@@ -123,6 +122,7 @@ int main( int argc, char* argv[] )
     QGuiApplication app( argc, argv );
 
     auto* horizontalBox = new QskLinearBox( Qt::Horizontal );
+    horizontalBox->setPanel( true );
     auto* button1 = new QskPushButton( "button 1", horizontalBox );
     auto* button2 = new QskPushButton( "button 2", horizontalBox );
 

--- a/doc/tutorials/03-writing-your-first-application.asciidoc
+++ b/doc/tutorials/03-writing-your-first-application.asciidoc
@@ -27,11 +27,11 @@ $ cmake ../ && make # build
 $ sudo make install # install
 ....
 
-To target a specific Qt version simply pass the cmake build variable `QSK_QT_VERSION` during the build step:
+To target a specific Qt version simply pass the cmake build variable `CMAKE_PREFIX_PATH` during the build step:
 
 [source,shell]
 ....
-$ cmake -DQSK_QT_VERSION=Qt5 ../ && make
+$ cmake -DCMAKE_PREFIX_PATH=/usr/local/Qt-6.7.0 ../ && make
 ....
 
 === Compiling our first app


### PR DESCRIPTION
This is a follow up to https://github.com/uwerat/qskinny/pull/355

and a response to: https://github.com/uwerat/qskinny/pull/364#issuecomment-1890442873

The build process will now use CMAKE_PREFIX_PATH to search for Qt versions but it still maintains the fix for proper sorting on Linux platforms to always build QSkinny at the intended targeted version.