### PR TITLE
fix issue with building with both examples and playground disabled

### DIFF
--- a/cmake/QskFindMacros.cmake
+++ b/cmake/QskFindMacros.cmake
@@ -24,6 +24,8 @@ macro(qsk_setup_Qt)
     else()
         message(FATAL_ERROR "Couldn't find any Qt package !")
     endif()
+    
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Quick)
 
     # Using find_package is probably no good idea as all other Qt modules should
     # be located below ${_qt_cmake_dir}. Otherwise we might end up with modules


### PR DESCRIPTION
When building qskinny with both `-DBUILD_EXAMPLES=OFF `and `-DBUILD_PLAYGROUND=OFF`, cmake cannot find the QtQuick library. Probably it gets pulled as part of QuickWidgets and WebEngine