### PR TITLE
Material3: Convert font sizes properly

### DIFF
--- a/designsystems/material3/QskMaterial3Skin.cpp
+++ b/designsystems/material3/QskMaterial3Skin.cpp
@@ -1456,12 +1456,15 @@ QskMaterial3Skin::~QskMaterial3Skin()
 {
 }
 
-static inline QFont createFont( int size, int lineHeight,
+static inline QFont createFont( int pointSize, int lineHeight,
     qreal spacing, QFont::Weight weight )
 {
     Q_UNUSED( lineHeight );
 
-    const int pixelSize = qRound( qskDpToPixels( size ) );
+    // convert to px according to https://www.w3.org/TR/css3-values/#absolute-lengths :
+    const double pxSize = pointSize / 72.0 * 96.0;
+
+    const int pixelSize = qRound( qskDpToPixels( pxSize ) );
 
     QFont font( QStringLiteral( "Roboto" ), -1, weight );
 


### PR DESCRIPTION
We need to convert the pt size to px before calculating our resolution dependent pixel size.

Before:

![Screenshot from 2024-09-30 16-12-27](https://github.com/user-attachments/assets/1398d288-dd0b-428f-8f4d-b53192727f72)

After:

![Screenshot from 2024-09-30 16-12-09](https://github.com/user-attachments/assets/b9d2e59c-3ad2-4d55-892c-0e503ed19b53)
