### PR TITLE
Features/anchoring

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,7 @@ list(APPEND HEADERS
     controls/QskGraphicLabelSkinlet.h
     controls/QskHintAnimator.h
     controls/QskItem.h
+    controls/QskItemAnchors.h
     controls/QskListView.h
     controls/QskListViewSkinlet.h
     controls/QskMenu.h
@@ -325,6 +326,7 @@ list(APPEND SOURCES
     controls/QskInputGrabber.cpp
     controls/QskItem.cpp
     controls/QskItemPrivate.cpp
+    controls/QskItemAnchors.cpp
     controls/QskListView.cpp
     controls/QskListViewSkinlet.cpp
     controls/QskMenuSkinlet.cpp

--- a/src/controls/QskItemAnchors.cpp
+++ b/src/controls/QskItemAnchors.cpp
@@ -1,0 +1,145 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskItemAnchors.h"
+#include "QskMargins.h"
+
+QSK_QT_PRIVATE_BEGIN
+#include <private/qquickanchors_p.h>
+#include <private/qquickanchors_p_p.h>
+QSK_QT_PRIVATE_END
+
+namespace
+{
+    inline QQuickAnchors::Anchor toQuickAnchor( Qt::AnchorPoint edge )
+    {
+        switch( edge )
+        {
+            case Qt::AnchorLeft:
+                return QQuickAnchors::LeftAnchor;
+
+            case Qt::AnchorHorizontalCenter:
+                return QQuickAnchors::HCenterAnchor;
+
+            case Qt::AnchorRight:
+                return QQuickAnchors::RightAnchor;
+
+            case Qt::AnchorTop:
+                return QQuickAnchors::TopAnchor;
+
+            case Qt::AnchorVerticalCenter:
+                return QQuickAnchors::VCenterAnchor;
+
+            case Qt::AnchorBottom:
+                return QQuickAnchors::BottomAnchor;
+        }
+
+        return QQuickAnchors::InvalidAnchor;
+    }
+
+    struct AnchorOperators
+    {
+        QQuickAnchorLine ( QQuickAnchors::*line ) () const;
+        void ( QQuickAnchors::*setLine )( const QQuickAnchorLine& );
+        void ( QQuickAnchors::*resetLine )();
+    };
+
+    const AnchorOperators& operators( Qt::AnchorPoint edge )
+    {
+        using A = QQuickAnchors;
+
+        static constexpr AnchorOperators table[] =
+        {
+            // in order of Qt::AnchorPoint
+
+            { &A::left, &A::setLeft, &A::resetLeft },
+            { &A::horizontalCenter, &A::setHorizontalCenter, &A::resetHorizontalCenter },
+            { &A::right, &A::setRight, &A::resetRight },
+            { &A::top, &A::setTop, &A::resetTop },
+            { &A::verticalCenter, &A::setVerticalCenter, &A::resetVerticalCenter },
+            { &A::bottom, &A::setBottom, &A::resetBottom }
+        };
+
+        return table[edge];
+    }
+}
+
+QskItemAnchors::QskItemAnchors()
+{
+}
+
+QskItemAnchors::~QskItemAnchors()
+{
+}
+
+QQuickItem* QskItemAnchors::item() const
+{
+    return m_anchors ? QQuickAnchorsPrivate::get( m_anchors )->item : nullptr;
+}
+
+QMarginsF QskItemAnchors::margins() const
+{
+    if ( !isValid() )
+        return QMarginsF();
+
+    return QMarginsF( m_anchors->leftMargin(), m_anchors->topMargin(),
+        m_anchors->rightMargin(), m_anchors->bottomMargin() );
+}
+
+void QskItemAnchors::setMargins( const QMarginsF& margins )
+{
+    m_anchors->setLeftMargin( margins.left() );
+    m_anchors->setRightMargin( margins.right() );
+    m_anchors->setTopMargin( margins.top() );
+    m_anchors->setBottomMargin( margins.bottom() );
+}
+
+void QskItemAnchors::addAnchor( QQuickItem* otherItem,
+    Qt::AnchorPoint otherEdge, Qt::AnchorPoint edge )
+{
+    const auto& ops = operators( edge );
+    ( m_anchors->*ops.setLine )( { otherItem, toQuickAnchor( otherEdge ) } );
+}
+
+void QskItemAnchors::removeAnchor( Qt::AnchorPoint edge )
+{
+    const auto& ops = operators( edge );
+    ( m_anchors->*ops.resetLine ) ();
+}
+
+void QskItemAnchors::addAnchors( QQuickItem* otherItem,
+    Qt::Corner otherCorner, Qt::Corner corner )
+{
+    auto anchorPoint =
+        []( Qt::Corner corner, Qt::Orientation orientation )
+        {
+            if ( orientation == Qt::Horizontal )
+                return ( corner & 0x1 ) ? Qt::AnchorRight : Qt::AnchorLeft;
+            else
+                return ( corner >= 0x2 ) ? Qt::AnchorBottom : Qt::AnchorTop;
+        };
+
+    addAnchor( otherItem, anchorPoint( otherCorner, Qt::Horizontal ),
+        anchorPoint( corner, Qt::Horizontal ) );
+
+    addAnchor( otherItem, anchorPoint( otherCorner, Qt::Vertical ),
+        anchorPoint( corner, Qt::Vertical ) );
+}
+
+void QskItemAnchors::addAnchors( QQuickItem* otherItem, Qt::Orientations orientations )
+{
+    if ( orientations & Qt::Horizontal )
+    {
+        addAnchor( otherItem, Qt::AnchorLeft, Qt::AnchorLeft );
+        addAnchor( otherItem, Qt::AnchorRight, Qt::AnchorRight );
+    }
+
+    if ( orientations & Qt::Vertical )
+    {
+        addAnchor( otherItem, Qt::AnchorTop, Qt::AnchorTop );
+        addAnchor( otherItem, Qt::AnchorBottom, Qt::AnchorBottom );
+    }
+}
+

--- a/src/controls/QskItemAnchors.cpp
+++ b/src/controls/QskItemAnchors.cpp
@@ -96,8 +96,8 @@ namespace
 }
 
 QskItemAnchors::QskItemAnchors( QQuickItem* anchoredItem )
+    : m_anchoredItem( anchoredItem )
 {
-    Q_UNUSED( anchoredItem );
 }
 
 QskItemAnchors::~QskItemAnchors()

--- a/src/controls/QskItemAnchors.h
+++ b/src/controls/QskItemAnchors.h
@@ -11,18 +11,43 @@
 #include <qpointer.h>
 
 class QMarginsF;
-class QQuickAnchors;
 class QQuickItem;
 
-class QskItemAnchors
+/*
+    QskItemAnchors is a C++ API to access the Qt/Quick anchoring,
+    that has been designed to be used from QML.
+
+    Qt/Quick anchoring is a simple concept, that adjusts the
+    edges of the anchoredItem whenever the geometry of a baseItem
+    has changed. A baseItem needs to be the parent or a sibling
+    of the anchoredItem.
+
+    Note that Qt/Quick anchoring is labeled as "positioner", what means
+    that it is not capable of handling typical layout scenarios, like
+    distributing the space of a bounding rectangle to a chainn of
+    anchored children.
+
+    For some reason the implementation allows to define conflicting definitions
+    and resolves them by applying only one of the definitions in
+    the following precedence:
+
+        1) fill
+        2) centerIn
+        3) anchors
+
+    Limitations:
+        - access to baseline settings are not implemented
+ */
+class QSK_EXPORT QskItemAnchors
 {
   public:
-    QskItemAnchors();
+    QskItemAnchors( QQuickItem* = nullptr );
     ~QskItemAnchors();
 
-    QQuickItem* item() const;
+    QQuickItem* anchoredItem() const;
 
-    bool isValid() const;
+    QQuickItem* baseItem( Qt::AnchorPoint ) const;
+    Qt::AnchorPoint basePosition( Qt::AnchorPoint ) const;
 
     bool operator==( const QskItemAnchors& ) const noexcept;
     bool operator!=( const QskItemAnchors& ) const noexcept;
@@ -30,31 +55,35 @@ class QskItemAnchors
     QMarginsF margins() const;
     void setMargins( const QMarginsF& );
 
-    void addAnchor( QQuickItem*, Qt::AnchorPoint, Qt::AnchorPoint );
-    void addAnchors( QQuickItem*, Qt::Corner, Qt::Corner );
+    void setCenterOffset( Qt::Orientation, qreal offset );
+    qreal centerOffset( Qt::Orientation );
+
+    void addAnchor( Qt::AnchorPoint, QQuickItem*, Qt::AnchorPoint );
+    void addAnchors( Qt::Corner, QQuickItem*, Qt::Corner );
     void addAnchors( QQuickItem*, Qt::Orientations = Qt::Horizontal | Qt::Vertical );
 
     void removeAnchor( Qt::AnchorPoint );
 
-  private:
-    QPointer< QQuickAnchors > m_anchors;
-};
+    /*
+        Qt/Quick anchoring knows the convenience modes "fill" and "centerIn".
+        Internally these modes are not(!) mapped to anchor definitions.
 
-inline bool QskItemAnchors::operator==(
-    const QskItemAnchors& other ) const noexcept
-{
-    return m_anchors.data() == other.m_anchors.data();
-}
+        Both modes are setting the center point of the anchoredItem to the center
+        of the controlItem. "fill" also adjusts the size.
+     */
+
+    QQuickItem* controlItem( bool adjustSize ) const;
+    void setControlItem( QQuickItem*, bool adjustSize );
+    void removeControlItem( bool adjustSize );
+
+  private:
+    QPointer< QQuickItem > m_anchoredItem;
+};
 
 inline bool QskItemAnchors::operator!=(
     const QskItemAnchors& other ) const noexcept
 {
     return !( *this == other );
-}
-
-inline bool QskItemAnchors::isValid() const
-{
-    return !m_anchors.isNull();
 }
 
 #endif

--- a/src/controls/QskItemAnchors.h
+++ b/src/controls/QskItemAnchors.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#ifndef QSK_ITEM_ANCHORS_H
+#define QSK_ITEM_ANCHORS_H
+
+#include "QskGlobal.h"
+#include <qnamespace.h>
+#include <qpointer.h>
+
+class QMarginsF;
+class QQuickAnchors;
+class QQuickItem;
+
+class QskItemAnchors
+{
+  public:
+    QskItemAnchors();
+    ~QskItemAnchors();
+
+    QQuickItem* item() const;
+
+    bool isValid() const;
+
+    bool operator==( const QskItemAnchors& ) const noexcept;
+    bool operator!=( const QskItemAnchors& ) const noexcept;
+
+    QMarginsF margins() const;
+    void setMargins( const QMarginsF& );
+
+    void addAnchor( QQuickItem*, Qt::AnchorPoint, Qt::AnchorPoint );
+    void addAnchors( QQuickItem*, Qt::Corner, Qt::Corner );
+    void addAnchors( QQuickItem*, Qt::Orientations = Qt::Horizontal | Qt::Vertical );
+
+    void removeAnchor( Qt::AnchorPoint );
+
+  private:
+    QPointer< QQuickAnchors > m_anchors;
+};
+
+inline bool QskItemAnchors::operator==(
+    const QskItemAnchors& other ) const noexcept
+{
+    return m_anchors.data() == other.m_anchors.data();
+}
+
+inline bool QskItemAnchors::operator!=(
+    const QskItemAnchors& other ) const noexcept
+{
+    return !( *this == other );
+}
+
+inline bool QskItemAnchors::isValid() const
+{
+    return !m_anchors.isNull();
+}
+
+#endif


### PR DESCRIPTION
QskItemAnchors introduced - a wrapper for QQuickAnchors to allow Qt/Quick anchoring without having to use private methods