### PR TITLE
spin box: Improve for M3

### DIFF
--- a/designsystems/material3/QskMaterial3Skin.cpp
+++ b/designsystems/material3/QskMaterial3Skin.cpp
@@ -898,6 +898,7 @@ void Editor::setupSpinBox()
 
     setHint( Q::Panel | QskAspect::Style, Q::ButtonsLeftAndRight );
 
+    setStrutSize( Q::Panel, -1.0, 48_dp );
     setBoxShape( Q::Panel, 4_dp );
     setBoxBorderMetrics( Q::Panel, 1_dp );
 
@@ -909,21 +910,25 @@ void Editor::setupSpinBox()
     setSpacing( Q::Panel, 4_dp );
 
     setStrutSize( Q::TextPanel, 80_dp, 40_dp );
-    setStrutSize( Q::UpPanel, 40_dp,40_dp );
+    setStrutSize( Q::UpPanel, 40_dp, 40_dp );
     setStrutSize( Q::DownPanel, 40_dp, 40_dp );
 
     setAlignment( Q::Text, Qt::AlignCenter );
 
     for( const auto subControl : { Q::DownPanel, Q::UpPanel, Q::TextPanel } )
     {
-        setBoxShape( subControl, 4_dp );
         setBoxBorderMetrics( subControl, 1_dp );
     }
+
+    setBoxShape( Q::TextPanel, 4_dp );
+
+    setBoxShape( Q::DownPanel, 100, Qt::RelativeSize );
+    setBoxShape( Q::UpPanel, 100, Qt::RelativeSize );
 
     for( const auto subControl : { Q::DownPanel, Q::UpPanel } )
     {
         setGradient( subControl | Q::Hovered, m_pal.primary8 );
-        setPadding( subControl, 10 );
+        setPadding( subControl, 11_dp );
     }
 
     {

--- a/src/controls/QskSpinBox.cpp
+++ b/src/controls/QskSpinBox.cpp
@@ -139,6 +139,8 @@ QskSpinBox::QskSpinBox( qreal min, qreal max, qreal stepSize, QQuickItem* parent
     setBoundaries( min, max );
     setStepSize( stepSize );
 
+    setAcceptHoverEvents( true );
+
     setAcceptedMouseButtons( Qt::LeftButton );
     setFocusPolicy( Qt::StrongFocus );
 
@@ -300,6 +302,36 @@ void QskSpinBox::mouseUngrabEvent()
 {
     if ( m_data->isActivatedByMouse() )
         m_data->setAutoRepeat( this, 0.0 );
+}
+
+void QskSpinBox::hoverEnterEvent( QHoverEvent* event )
+{
+    using A = QskAspect;
+
+    setSkinHint( UpPanel | Hovered | A::Metric | A::Position, qskHoverPosition( event ) );
+    setSkinHint( DownPanel | Hovered | A::Metric | A::Position, qskHoverPosition( event ) );
+
+    update();
+}
+
+void QskSpinBox::hoverMoveEvent( QHoverEvent* event )
+{
+    using A = QskAspect;
+
+    setSkinHint( UpPanel | Hovered | A::Metric | A::Position, qskHoverPosition( event ) );
+    setSkinHint( DownPanel | Hovered | A::Metric | A::Position, qskHoverPosition( event ) );
+
+    update();
+}
+
+void QskSpinBox::hoverLeaveEvent( QHoverEvent* )
+{
+    using A = QskAspect;
+
+    setSkinHint( UpPanel | Hovered | A::Metric | A::Position, QPointF() );
+    setSkinHint( DownPanel | Hovered | A::Metric | A::Position, QPointF() );
+
+    update();
 }
 
 void QskSpinBox::keyPressEvent( QKeyEvent* event )

--- a/src/controls/QskSpinBox.h
+++ b/src/controls/QskSpinBox.h
@@ -75,6 +75,10 @@ class QSK_EXPORT QskSpinBox : public QskBoundedValueInput
     void mousePressEvent( QMouseEvent* ) override;
     void mouseUngrabEvent() override;
 
+    void hoverEnterEvent( QHoverEvent* ) override;
+    void hoverMoveEvent( QHoverEvent* ) override;
+    void hoverLeaveEvent( QHoverEvent* ) override;
+
     void keyPressEvent( QKeyEvent* ) override;
     void keyReleaseEvent( QKeyEvent* ) override;
 

--- a/src/controls/QskSpinBoxSkinlet.cpp
+++ b/src/controls/QskSpinBoxSkinlet.cpp
@@ -14,22 +14,39 @@ static inline QskAspect::States qskButtonStates(
     const QskSkinnable* skinnable, QskAspect::Subcontrol subControl )
 {
     using Q = QskSpinBox;
+    using A = QskAspect;
 
     auto spinBox = static_cast< const QskSpinBox* >( skinnable );
 
     auto states = spinBox->skinStates();
 
-    if ( spinBox->isEnabled() && !spinBox->isWrapping() )
+    if ( spinBox->isEnabled() )
     {
         if ( subControl == Q::DownIndicator || subControl == Q::DownPanel )
         {
-            if ( spinBox->value() <= spinBox->minimum() )
+            if ( !spinBox->isWrapping() && spinBox->value() <= spinBox->minimum() )
                 states |= QskControl::Disabled;
+
+            const auto cursorPos = spinBox->effectiveSkinHint(
+                Q::DownPanel | Q::Hovered | A::Metric | A::Position ).toPointF();
+
+            if( !cursorPos.isNull() && spinBox->subControlRect( Q::DownPanel ).contains( cursorPos ) )
+            {
+                states |= Q::Hovered;
+            }
         }
         else if ( subControl == Q::UpIndicator || subControl == Q::UpPanel )
         {
-            if ( spinBox->value() >= spinBox->maximum() )
+            if ( !spinBox->isWrapping() && spinBox->value() >= spinBox->maximum() )
                 states |= QskControl::Disabled;
+
+            const auto cursorPos = spinBox->effectiveSkinHint(
+                Q::UpPanel | Q::Hovered | A::Metric | A::Position ).toPointF();
+
+            if( !cursorPos.isNull() && spinBox->subControlRect( Q::UpPanel ).contains( cursorPos ) )
+            {
+                states |= Q::Hovered;
+            }
         }
     }
 
@@ -46,9 +63,6 @@ QRectF QskSpinBoxSkinlet::subControlRect( const QskSkinnable* skinnable,
     const QRectF& contentsRect, QskAspect::Subcontrol subControl ) const
 {
     using Q = QskSpinBox;
-
-    QskSkinStateChanger stateChanger( skinnable );
-    stateChanger.setStates( qskButtonStates( skinnable, subControl ) );
 
     if ( subControl == Q::Panel )
         return contentsRect;


### PR DESCRIPTION
Resolves #398

normal:

![Screenshot from 2024-10-20 17-43-59](https://github.com/user-attachments/assets/da1d0c2c-8eed-4bd2-91c5-a8bd39e0c53b)

hovered:

![Screenshot from 2024-10-20 17-43-43](https://github.com/user-attachments/assets/57c9d9b5-e59c-457c-a10d-5b1b522ced8a)

pressed:

![Screenshot from 2024-10-20 17-44-03](https://github.com/user-attachments/assets/835cce80-87d9-43a3-87f3-2da0eb6ba323)

Comments:
- size of up/down buttons: normal push button size (i.e. height of 40 dp)
- emphasis: As mentioned in the ticket emphasis is like the very low button emphasis
- spin box height has been chosen to be the same as the menu height (48 dp). Different
  controls have different heights here, e.g. outlined text field has 56 dp and chips
  only 32 dp. So we could also chose another height here.
- size of icons: Same as push button icons.
  (Panel size is 40 dp, icon padding is 11 dp, so icon size is 40-2*11=18 dp)