### PR TITLE
progress indicators: Update to newest M3 spec

### DIFF
--- a/designsystems/material3/QskMaterial3Skin.cpp
+++ b/designsystems/material3/QskMaterial3Skin.cpp
@@ -486,22 +486,21 @@ void Editor::setupProgressBar()
     using A = QskAspect;
     using Q = QskProgressBar;
 
-    auto size = 4_dp;
-
     for ( auto subControl : { Q::Groove, Q::Fill } )
     {
-        setMetric( subControl | A::Size, size );
-        setPadding( subControl, 0 );
-
-        setBoxShape( subControl, 0 );
-        setBoxBorderMetrics( subControl, 0 );
+        setBoxShape( subControl, { 100, Qt::RelativeSize } );
+        setMetric( subControl | A::Size, 4_dp );
     }
 
-    setMetric( Q::Groove | A::Size, size );
     setGradient( Q::Groove, m_pal.surfaceContainerHighest );
-
     setGradient( Q::Groove | Q::Disabled, m_pal.onSurface12 );
 
+    setStrutSize( Q::GrooveStopIndicator, { 4_dp, 4_dp } );
+    setBoxShape( Q::GrooveStopIndicator, { 100, Qt::RelativeSize } );
+    setGradient( Q::GrooveStopIndicator, m_pal.primary );
+    setGradient( Q::GrooveStopIndicator | Q::Disabled, m_pal.onSurface38 );
+
+    setSpacing( Q::Fill, 4_dp );
     setGradient( Q::Fill, m_pal.primary );
     setGradient( Q::Fill | Q::Disabled, m_pal.onSurface38 );
 }
@@ -510,9 +509,15 @@ void Editor::setupProgressRing()
 {
     using Q = QskProgressRing;
 
+    setArcMetrics( Q::Groove, 90, -360, 4_dp );
+    setGradient( Q::Groove, m_pal.surfaceContainerHighest );
+    setGradient( Q::Groove | Q::Disabled, m_pal.onSurface12 );
+
+    setSpacing( Q::Fill, 10 );
     setStrutSize( Q::Fill, { 48_dp, 48_dp } );
-    setGradient( Q::Fill, m_pal.primary );
     setArcMetrics( Q::Fill, 90, -360, 4_dp );
+    setGradient( Q::Fill, m_pal.primary );
+    setGradient( Q::Fill | Q::Disabled, m_pal.onSurface38 );
 }
 
 void Editor::setupRadioBox()

--- a/src/controls/QskProgressBar.cpp
+++ b/src/controls/QskProgressBar.cpp
@@ -9,6 +9,7 @@
 
 QSK_SUBCONTROL( QskProgressBar, Groove )
 QSK_SUBCONTROL( QskProgressBar, Fill )
+QSK_SUBCONTROL( QskProgressBar, GrooveStopIndicator )
 
 class QskProgressBar::PrivateData
 {

--- a/src/controls/QskProgressBar.h
+++ b/src/controls/QskProgressBar.h
@@ -18,7 +18,7 @@ class QSK_EXPORT QskProgressBar : public QskProgressIndicator
     using Inherited = QskProgressIndicator;
 
   public:
-    QSK_SUBCONTROLS( Groove, Fill )
+    QSK_SUBCONTROLS( Groove, Fill, GrooveStopIndicator )
 
     QskProgressBar( Qt::Orientation, QQuickItem* parent = nullptr );
     QskProgressBar( Qt::Orientation, qreal min, qreal max, QQuickItem* parent = nullptr );

--- a/src/controls/QskProgressBarSkinlet.h
+++ b/src/controls/QskProgressBarSkinlet.h
@@ -17,6 +17,11 @@ class QSK_EXPORT QskProgressBarSkinlet : public QskProgressIndicatorSkinlet
     using Inherited = QskProgressIndicatorSkinlet;
 
   public:
+    enum NodeRole
+    {
+        GrooveStopIndicatorRole = Inherited::RoleCount,
+    };
+
     Q_INVOKABLE QskProgressBarSkinlet( QskSkin* = nullptr );
     ~QskProgressBarSkinlet() override;
 
@@ -26,12 +31,23 @@ class QSK_EXPORT QskProgressBarSkinlet : public QskProgressIndicatorSkinlet
     QSizeF sizeHint( const QskSkinnable*,
         Qt::SizeHint, const QSizeF& ) const override;
 
+    int sampleCount( const QskSkinnable*, QskAspect::Subcontrol ) const override;
+
+    QRectF sampleRect( const QskSkinnable*,
+        const QRectF&, QskAspect::Subcontrol, int index ) const override;
+
   protected:
+    QSGNode* updateSubNode( const QskSkinnable*, quint8 nodeRole, QSGNode* ) const override;
+
     QSGNode* updateGrooveNode( const QskProgressIndicator*, QSGNode* ) const override;
     QSGNode* updateFillNode( const QskProgressIndicator*, QSGNode* ) const override;
 
+    QSGNode* updateSampleNode( const QskSkinnable*,
+        QskAspect::Subcontrol, int index, QSGNode* ) const override;
+
   private:
     QRectF barRect( const QskProgressBar* ) const;
+    QRectF grooveStopIndicatorRect( const QskProgressBar* ) const;
 };
 
 #endif

--- a/src/controls/QskProgressIndicator.cpp
+++ b/src/controls/QskProgressIndicator.cpp
@@ -189,6 +189,11 @@ qreal QskProgressIndicator::origin() const
     return minimum();
 }
 
+bool QskProgressIndicator::hasOrigin() const
+{
+    return m_data->hasOrigin;
+}
+
 void QskProgressIndicator::setValue( qreal value )
 {
     if ( isComponentComplete() )

--- a/src/controls/QskProgressIndicator.h
+++ b/src/controls/QskProgressIndicator.h
@@ -51,6 +51,7 @@ class QSK_EXPORT QskProgressIndicator : public QskBoundedControl
 
     void resetOrigin();
     qreal origin() const;
+    bool hasOrigin() const;
 
     qreal value() const;
     qreal valueAsRatio() const; // [0.0, 1.0]

--- a/src/controls/QskProgressRingSkinlet.h
+++ b/src/controls/QskProgressRingSkinlet.h
@@ -29,8 +29,6 @@ class QSK_EXPORT QskProgressRingSkinlet : public QskProgressIndicatorSkinlet
   protected:
     QSGNode* updateGrooveNode( const QskProgressIndicator*, QSGNode* ) const override;
     QSGNode* updateFillNode( const QskProgressIndicator*, QSGNode* ) const override;
-
-    QskIntervalF fillInterval( const QskProgressIndicator* ) const;
 };
 
 #endif


### PR DESCRIPTION
![Screenshot from 2024-11-04 13-58-45](https://github.com/user-attachments/assets/5dcba1f2-002d-4ab8-9701-d57eee8a1f1e)

I had to introduce a distinction for both progress bars and progress rings whether the groove is one piece or two:

- If it is one piece (F2 and Fusion), we want to draw the full groove below the fill, otherwise it would look strange: (The screenshot below shows the strange behavior that is being avoided with this PR).

![Screenshot from 2024-10-29 09-16-05](https://github.com/user-attachments/assets/716fab1d-92f5-49fc-a709-2c16a9bfbc32)

- If it is two pieces, we need to have a spacing between groove and fill, see the first screenshot above, which we cannot achieve with only one groove bar or arc.