### PR TITLE
text edit: Support enter key

### DIFF
--- a/src/controls/QskTextEdit.cpp
+++ b/src/controls/QskTextEdit.cpp
@@ -294,13 +294,20 @@ void QskTextEdit::keyPressEvent( QKeyEvent* event )
             {
                 QGuiApplication::inputMethod()->commit();
 
-                if ( !( inputMethodHints() & Qt::ImhMultiLine ) )
+                const auto hints = inputMethodQuery( Qt::ImHints ).toInt();
+
+                if ( hints & Qt::ImhMultiLine )
+                {
+                    m_data->wrappedEdit->handleEvent( event );
+                }
+                else
                 {
                     setEditing( false );
 
                     // When returning from a virtual keyboard
                     qskForceActiveFocus( this, Qt::PopupFocusReason );
                 }
+
                 break;
             }
 #if 1

--- a/src/controls/QskTextInput.cpp
+++ b/src/controls/QskTextInput.cpp
@@ -308,7 +308,13 @@ void QskTextInput::keyPressEvent( QKeyEvent* event )
                 {
                     QGuiApplication::inputMethod()->commit();
 
-                    if ( !( inputMethodHints() & Qt::ImhMultiLine ) )
+                    const auto hints = inputMethodQuery( Qt::ImHints ).toInt();
+
+                    if ( hints & Qt::ImhMultiLine )
+                    {
+                        m_data->wrappedInput->handleEvent( event );
+                    }
+                    else
                     {
                         setEditing( false );
 
@@ -316,6 +322,7 @@ void QskTextInput::keyPressEvent( QKeyEvent* event )
                         qskForceActiveFocus( this, Qt::PopupFocusReason );
                     }
                 }
+
                 break;
             }
 #if 1


### PR DESCRIPTION
It turns out inputMethodHints() is sort of a user setting; when querying the hints in inputMethodQuery(), QQuickTextEdit adds the Qt::ImMultiLine flag manually.