### PR TITLE
implement dialogs for selection of file / directory / color / font

### DIFF
--- a/examples/gallery/dialog/DialogPage.cpp
+++ b/examples/gallery/dialog/DialogPage.cpp
@@ -107,6 +107,9 @@ namespace
             auto colorSelectionButton = new Button( "Color selection", this );
             connect( colorSelectionButton, &Button::clicked, this, &ButtonBox::execColorSelection );
 
+            auto fontSelectionButton = new Button( "Font selection", this );
+            connect( fontSelectionButton, &Button::clicked, this, &ButtonBox::execFontSelection );
+
             setExtraSpacingAt( Qt::BottomEdge );
         }
 
@@ -193,6 +196,15 @@ namespace
             // not implemented for now (class is not public)
 #else
             ( void ) qskDialog->selectColor( "select color" );
+#endif
+        }
+
+        void execFontSelection()
+        {
+#ifndef QSK_USE_EXEC
+            // not implemented for now (class is not public)
+#else
+            ( void ) qskDialog->selectFont( "select font" );
 #endif
         }
     };

--- a/examples/gallery/dialog/DialogPage.cpp
+++ b/examples/gallery/dialog/DialogPage.cpp
@@ -101,6 +101,9 @@ namespace
             auto fileSelectionButton = new Button( "File selection", this );
             connect( fileSelectionButton, &Button::clicked, this, &ButtonBox::execFileSelection );
 
+            auto directorySelectionButton = new Button( "Directory selection", this );
+            connect( directorySelectionButton, &Button::clicked, this, &ButtonBox::execDirectorySelection );
+
             setExtraSpacingAt( Qt::BottomEdge );
         }
 
@@ -169,6 +172,15 @@ namespace
             // not implemented for now (class is not public)
 #else
             ( void ) qskDialog->selectFile( "select file", QDir::currentPath() );
+#endif
+        }
+
+        void execDirectorySelection()
+        {
+#ifndef QSK_USE_EXEC
+            // not implemented for now (class is not public)
+#else
+            ( void ) qskDialog->selectDirectory( "select directory", QDir::currentPath() );
 #endif
         }
     };

--- a/examples/gallery/dialog/DialogPage.cpp
+++ b/examples/gallery/dialog/DialogPage.cpp
@@ -104,6 +104,9 @@ namespace
             auto directorySelectionButton = new Button( "Directory selection", this );
             connect( directorySelectionButton, &Button::clicked, this, &ButtonBox::execDirectorySelection );
 
+            auto colorSelectionButton = new Button( "Color selection", this );
+            connect( colorSelectionButton, &Button::clicked, this, &ButtonBox::execColorSelection );
+
             setExtraSpacingAt( Qt::BottomEdge );
         }
 
@@ -181,6 +184,15 @@ namespace
             // not implemented for now (class is not public)
 #else
             ( void ) qskDialog->selectDirectory( "select directory", QDir::currentPath() );
+#endif
+        }
+
+        void execColorSelection()
+        {
+#ifndef QSK_USE_EXEC
+            // not implemented for now (class is not public)
+#else
+            ( void ) qskDialog->selectColor( "select color" );
 #endif
         }
     };

--- a/examples/gallery/dialog/DialogPage.cpp
+++ b/examples/gallery/dialog/DialogPage.cpp
@@ -9,6 +9,8 @@
 #include <QskLinearBox.h>
 #include <QskPushButton.h>
 
+#include <QDir>
+
 #if QT_CONFIG(thread)
     /*
         WebAssembly without asyncify support does not allow recursive
@@ -96,6 +98,9 @@ namespace
             auto selectButton = new Button( "Selection", this );
             connect( selectButton, &Button::clicked, this, &ButtonBox::execSelection );
 
+            auto fileSelectionButton = new Button( "File selection", this );
+            connect( fileSelectionButton, &Button::clicked, this, &ButtonBox::execFileSelection );
+
             setExtraSpacingAt( Qt::BottomEdge );
         }
 
@@ -155,6 +160,15 @@ namespace
                 QskDialog::Ok | QskDialog::Cancel, QskDialog::Ok, entries, 7 );
 #else
             (void )qskDialog->select( title, entries, 7 );
+#endif
+        }
+
+        void execFileSelection()
+        {
+#ifndef QSK_USE_EXEC
+            // not implemented for now (class is not public)
+#else
+            ( void ) qskDialog->selectFile( "select file", QDir::currentPath() );
 #endif
         }
     };

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -111,6 +111,12 @@ namespace
             {
                 switch( dialogType )
                 {
+                    case ColorDialog:
+                    {
+                        auto color = qskDialog->selectColor( "select color" );
+                        qDebug() << "selected color" << QColor( color );
+                        break;
+                    }
                     case FileDialog:
                     {
                         auto file = qskDialog->selectFile( "select file", QDir::currentPath() );

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -11,6 +11,7 @@
 #include <QskCheckBox.h>
 #include <QskLinearBox.h>
 #include <QskMainView.h>
+#include <QskDialog.h>
 
 #include <QGuiApplication>
 
@@ -108,10 +109,29 @@ namespace
 
             if ( qGuiApp->testAttribute( Qt::AA_DontUseNativeDialogs ) )
             {
-                const auto metaEnum = QMetaEnum::fromType<DialogType>();
-                m_dialog = createQml( metaEnum.key( dialogType ) );
-                if ( m_dialog )
-                    m_dialog->setParentWindow( window() );
+                switch( dialogType )
+                {
+                    case FileDialog:
+                    {
+                        auto file = qskDialog->selectFile( "select file", "." );
+                        qDebug() << "selected file" << file;
+                        break;
+                    }
+                    case MessageDialog:
+                    {
+                        auto action = qskDialog->message( "message", "The quick brown fox jumps over the lazy dog" );
+                        qDebug() << "got message action" << action;
+                        break;
+                    }
+                    default:
+                    {
+                        const auto metaEnum = QMetaEnum::fromType<DialogType>();
+                        m_dialog = createQml( metaEnum.key( dialogType ) );
+
+                        if ( m_dialog )
+                            m_dialog->setParentWindow( window() );
+                    }
+                }
             }
             else
             {

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -114,7 +114,11 @@ namespace
                     case FileDialog:
                     {
                         auto file = qskDialog->selectFile( "select file", QDir::currentPath() );
-                        qDebug() << "selected file" << file;
+                        break;
+                    }
+                    case FolderDialog:
+                    {
+                        auto file = qskDialog->selectDirectory( "select directory", QDir::currentPath() );
                         break;
                     }
                     case MessageDialog:

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -21,34 +21,6 @@
 #include <private/qquickfontdialog_p.h>
 #include <private/qquickmessagedialog_p.h>
 
-#include <QtQml>
-
-static QQuickAbstractDialog* createQml( const char* className )
-{
-    static QQmlEngine engine( nullptr );
-
-    QByteArray qmlCode = "import QtQuick.Dialogs\n";
-    qmlCode += className;
-    qmlCode += " {}";
-
-    auto component = new QQmlComponent( &engine );
-    component->setData( qmlCode.constData(), QUrl() );
-
-    if ( component->status() != QQmlComponent::Ready )
-    {
-        qWarning() << component->errorString();
-        delete component;
-
-        return nullptr;
-    }
-
-    auto dialog = qobject_cast< QQuickAbstractDialog* >( component->create() );
-    QObject::connect( dialog, &QObject::destroyed,
-        component, &QObject::deleteLater );
-
-    return dialog;
-}
-
 namespace
 {
     class ButtonBox : public QskLinearBox
@@ -126,6 +98,11 @@ namespace
                         auto file = qskDialog->selectDirectory( "select directory", QDir::currentPath() );
                         break;
                     }
+                    case FontDialog:
+                    {
+                        qskDialog->selectFont( "select font" );
+                        break;
+                    }
                     case MessageDialog:
                     {
                         auto action = qskDialog->message( "message", "The quick brown fox jumps over the lazy dog" );
@@ -134,11 +111,7 @@ namespace
                     }
                     default:
                     {
-                        const auto metaEnum = QMetaEnum::fromType<DialogType>();
-                        m_dialog = createQml( metaEnum.key( dialogType ) );
-
-                        if ( m_dialog )
-                            m_dialog->setParentWindow( window() );
+                        qWarning() << "unknown dialog type detected";
                     }
                 }
             }

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -90,12 +90,12 @@ namespace
                     }
                     case FileDialog:
                     {
-                        auto file = qskDialog->selectFile( "select file", QDir::currentPath() );
+                        qskDialog->selectFile( "select file", QDir::currentPath() );
                         break;
                     }
                     case FolderDialog:
                     {
-                        auto file = qskDialog->selectDirectory( "select directory", QDir::currentPath() );
+                        qskDialog->selectDirectory( "select directory", QDir::currentPath() );
                         break;
                     }
                     case FontDialog:
@@ -105,8 +105,7 @@ namespace
                     }
                     case MessageDialog:
                     {
-                        auto action = qskDialog->message( "message", "The quick brown fox jumps over the lazy dog" );
-                        qDebug() << "got message action" << action;
+                        qskDialog->message( "message", "The quick brown fox jumps over the lazy dog" );
                         break;
                     }
                     default:

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -113,8 +113,7 @@ namespace
                 {
                     case ColorDialog:
                     {
-                        auto color = qskDialog->selectColor( "select color" );
-                        qDebug() << "selected color" << QColor( color );
+                        qskDialog->selectColor( "select color" );
                         break;
                     }
                     case FileDialog:

--- a/playground/systemdialogs/main.cpp
+++ b/playground/systemdialogs/main.cpp
@@ -113,7 +113,7 @@ namespace
                 {
                     case FileDialog:
                     {
-                        auto file = qskDialog->selectFile( "select file", "." );
+                        auto file = qskDialog->selectFile( "select file", QDir::currentPath() );
                         qDebug() << "selected file" << file;
                         break;
                     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -457,20 +457,26 @@ list(APPEND HEADERS
 list(APPEND PRIVATE_HEADERS
     dialogs/QskColorPicker.h
     dialogs/QskColorPickerSkinlet.h
+    dialogs/QskColorSelectionWindow.h
+    dialogs/QskFileSelectionWindow.h
+    dialogs/QskWindowOrSubWindow.h
 )
 
 list(APPEND SOURCES
     dialogs/QskColorPicker.cpp
     dialogs/QskColorPickerSkinlet.cpp
+    dialogs/QskColorSelectionWindow.cpp
     dialogs/QskDialogButton.cpp
     dialogs/QskDialogButtonBox.cpp
     dialogs/QskDialog.cpp
     dialogs/QskDialogSubWindow.cpp
     dialogs/QskDialogWindow.cpp
+    dialogs/QskFileSelectionWindow.cpp
     dialogs/QskMessageSubWindow.cpp
     dialogs/QskMessageWindow.cpp
     dialogs/QskSelectionSubWindow.cpp
     dialogs/QskSelectionWindow.cpp
+    dialogs/QskWindowOrSubWindow.cpp
 )
 
 list(APPEND HEADERS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -459,6 +459,7 @@ list(APPEND PRIVATE_HEADERS
     dialogs/QskColorPickerSkinlet.h
     dialogs/QskColorSelectionWindow.h
     dialogs/QskFileSelectionWindow.h
+    dialogs/QskFontSelectionWindow.h
     dialogs/QskWindowOrSubWindow.h
 )
 
@@ -472,6 +473,7 @@ list(APPEND SOURCES
     dialogs/QskDialogSubWindow.cpp
     dialogs/QskDialogWindow.cpp
     dialogs/QskFileSelectionWindow.cpp
+    dialogs/QskFontSelectionWindow.cpp
     dialogs/QskMessageSubWindow.cpp
     dialogs/QskMessageWindow.cpp
     dialogs/QskSelectionSubWindow.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -454,7 +454,14 @@ list(APPEND HEADERS
     dialogs/QskSelectionWindow.h
 )
 
+list(APPEND PRIVATE_HEADERS
+    dialogs/QskColorPicker.h
+    dialogs/QskColorPickerSkinlet.h
+)
+
 list(APPEND SOURCES
+    dialogs/QskColorPicker.cpp
+    dialogs/QskColorPickerSkinlet.cpp
     dialogs/QskDialogButton.cpp
     dialogs/QskDialogButtonBox.cpp
     dialogs/QskDialog.cpp

--- a/src/controls/QskSkin.cpp
+++ b/src/controls/QskSkin.cpp
@@ -112,6 +112,9 @@
 #include "QskStatusIndicator.h"
 #include "QskStatusIndicatorSkinlet.h"
 
+#include "QskColorPicker.h"
+#include "QskColorPickerSkinlet.h"
+
 #include "QskInternalMacros.h"
 
 #include <qhash.h>
@@ -223,6 +226,7 @@ QskSkin::QskSkin( QObject* parent )
     declareSkinlet< QskProgressBar, QskProgressBarSkinlet >();
     declareSkinlet< QskProgressRing, QskProgressRingSkinlet >();
     declareSkinlet< QskRadioBox, QskRadioBoxSkinlet >();
+    declareSkinlet< QskColorPicker, QskColorPickerSkinlet >();
 
     const QFont font = QGuiApplication::font();
     setupFontTable( font.family(), font.italic() );

--- a/src/dialogs/QskColorPicker.cpp
+++ b/src/dialogs/QskColorPicker.cpp
@@ -8,6 +8,8 @@
 #include "QskEvent.h"
 #include "QskFunctions.h"
 
+#include <QQuickWindow>
+
 QSK_SUBCONTROL( QskColorPicker, Panel )
 QSK_SUBCONTROL( QskColorPicker, ColorPane )
 QSK_SUBCONTROL( QskColorPicker, Selector )
@@ -180,7 +182,10 @@ QPointF QskColorPicker::position() const
 void QskColorPicker::createImage()
 {
     const auto r = subControlRect( ColorPane );
-    ::createImage( &m_data->image, r.size(), valueAsRatio() );
+    const auto ratio = window() ? window()->effectiveDevicePixelRatio() : 1.0;
+    const auto size = r.size() * ratio;
+
+    ::createImage( &m_data->image, size, valueAsRatio() );
 }
 
 #include "moc_QskColorPicker.cpp"

--- a/src/dialogs/QskColorPicker.cpp
+++ b/src/dialogs/QskColorPicker.cpp
@@ -29,15 +29,16 @@ namespace
         QColor color;
         float h, s;
 
-        for( int x = 0; x < image->width(); x++ )
+        for ( int y = 0; y < image->height(); y++ )
         {
-            h = static_cast< float >( x ) / image->width();
+            s = 1.0 - static_cast< float >( y ) / image->height();
+            auto line = reinterpret_cast< QRgb* >( image->scanLine( y ) );
 
-            for( int y = 0; y < image->height(); y++ )
+            for ( int x = 0; x < image->width(); x++ )
             {
-                s = 1.0 - static_cast< float >( y ) / image->height();
+                h = static_cast< float >( x ) / image->width();
                 color.setHsvF( h, s, v );
-                image->setPixel( x, y, color.rgb() );
+                *line++ = color.rgb();
             }
         }
     }

--- a/src/dialogs/QskColorPicker.cpp
+++ b/src/dialogs/QskColorPicker.cpp
@@ -1,0 +1,126 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskColorPicker.h"
+#include "QskColorPickerSkinlet.h"
+#include "QskEvent.h"
+#include "QskFunctions.h"
+
+QSK_SUBCONTROL( QskColorPicker, Panel )
+QSK_SUBCONTROL( QskColorPicker, ColorPane )
+QSK_SUBCONTROL( QskColorPicker, Selector )
+
+class QskColorPicker::PrivateData
+{
+  public:
+    qreal value = 255;
+    bool isPressed = false;
+    int colorChangedEventType;
+};
+
+QskColorPicker::QskColorPicker( QQuickItem* parent )
+    : Inherited( parent )
+    , m_data( new PrivateData )
+{
+    m_data->colorChangedEventType = QEvent::registerEventType();
+
+    setAcceptedMouseButtons( Qt::LeftButton );
+    setBoundaries( 0, 255 );
+}
+
+QskColorPicker::~QskColorPicker() = default;
+
+QColor QskColorPicker::selectedColor() const
+{
+    auto* skinlet = static_cast< const QskColorPickerSkinlet* >( effectiveSkinlet() );
+    Q_ASSERT( skinlet );
+    return skinlet->selectedColor();
+}
+
+qreal QskColorPicker::value() const
+{
+    return m_data->value;
+}
+
+qreal QskColorPicker::valueAsRatio() const
+{
+    return valueAsRatio( m_data->value );
+}
+
+int QskColorPicker::colorChangedEventType() const
+{
+    return m_data->colorChangedEventType;
+}
+
+void QskColorPicker::setValue( qreal v )
+{
+    if( !qskFuzzyCompare( m_data->value, v ) )
+    {
+        m_data->value = v;
+        update();
+        Q_EMIT valueChanged( m_data->value );
+    }
+}
+
+void QskColorPicker::setValueAsRatio( qreal ratio )
+{
+    ratio = qBound( 0.0, ratio, 1.0 );
+    setValue( minimum() + ratio * boundaryLength() );
+}
+
+bool QskColorPicker::event( QEvent* event )
+{
+    if( event->type() == colorChangedEventType() )
+    {
+        event->setAccepted( true );
+        Q_EMIT selectedColorChanged();
+        return true;
+    }
+
+    return Inherited::event( event );
+}
+
+void QskColorPicker::mousePressEvent( QMouseEvent* event )
+{
+    m_data->isPressed = true;
+    updatePosition( event );
+}
+
+void QskColorPicker::mouseMoveEvent( QMouseEvent* event )
+{
+    if( !m_data->isPressed )
+    {
+        return;
+    }
+
+    updatePosition( event );
+}
+
+void QskColorPicker::mouseReleaseEvent( QMouseEvent* )
+{
+    m_data->isPressed = false;
+}
+
+void QskColorPicker::updatePosition( QMouseEvent* event )
+{
+    auto p = qskMousePosition( event );
+    const auto rect = subControlRect( ColorPane );
+
+    p.rx() = qBound( rect.x(), p.x(), rect.right() );
+    p.ry() = qBound( rect.y(), p.y(), rect.bottom() );
+
+    const auto oldX = positionHint( Selector | QskAspect::Horizontal );
+    const auto oldY = positionHint( Selector | QskAspect::Vertical );
+
+    if( !qskFuzzyCompare( p.x(), oldX ) || !qskFuzzyCompare( p.y(), oldY ) )
+    {
+        setPositionHint( Selector | QskAspect::Horizontal, p.x() );
+        setPositionHint( Selector | QskAspect::Vertical, p.y() );
+
+        update();
+    }
+}
+
+#include "moc_QskColorPicker.cpp"

--- a/src/dialogs/QskColorPicker.h
+++ b/src/dialogs/QskColorPicker.h
@@ -28,7 +28,8 @@ class QskColorPicker : public QskBoundedControl
     qreal valueAsRatio() const; // [0.0, 1.0]
     using QskBoundedControl::valueAsRatio;
 
-    int colorChangedEventType() const;
+    QImage image() const;
+    QPointF position() const;
 
   public Q_SLOTS:
     void setValue( qreal );
@@ -37,15 +38,17 @@ class QskColorPicker : public QskBoundedControl
   Q_SIGNALS:
     void valueChanged( qreal );
     void selectedColorChanged() const;
+    void positionChanged() const;
 
   protected:
-    bool event( QEvent* ) override;
+    void updateLayout() override;
     void mousePressEvent( QMouseEvent* ) override;
     void mouseMoveEvent( QMouseEvent* ) override;
     void mouseReleaseEvent( QMouseEvent* ) override;
 
   private:
-    void updatePosition( QMouseEvent* );
+    void updatePosition( const QPointF& );
+    void createImage();
 
     class PrivateData;
     std::unique_ptr< PrivateData > m_data;

--- a/src/dialogs/QskColorPicker.h
+++ b/src/dialogs/QskColorPicker.h
@@ -37,8 +37,8 @@ class QskColorPicker : public QskBoundedControl
 
   Q_SIGNALS:
     void valueChanged( qreal );
-    void selectedColorChanged() const;
-    void positionChanged() const;
+    void selectedColorChanged();
+    void positionChanged();
 
   protected:
     void updateLayout() override;

--- a/src/dialogs/QskColorPicker.h
+++ b/src/dialogs/QskColorPicker.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#ifndef QSK_COLOR_PICKER_H
+#define QSK_COLOR_PICKER_H
+
+#include "QskBoundedControl.h"
+
+#include <memory>
+
+class QskColorPicker : public QskBoundedControl
+{
+    Q_OBJECT
+
+    using Inherited = QskBoundedControl;
+
+  public:
+    QSK_SUBCONTROLS( Panel, ColorPane, Selector )
+
+    QskColorPicker( QQuickItem* parentItem = nullptr );
+    ~QskColorPicker() override;
+
+    QColor selectedColor() const;
+
+    qreal value() const; // value as in hue / saturation / value
+    qreal valueAsRatio() const; // [0.0, 1.0]
+    using QskBoundedControl::valueAsRatio;
+
+    int colorChangedEventType() const;
+
+  public Q_SLOTS:
+    void setValue( qreal );
+    void setValueAsRatio( qreal );
+
+  Q_SIGNALS:
+    void valueChanged( qreal );
+    void selectedColorChanged() const;
+
+  protected:
+    bool event( QEvent* ) override;
+    void mousePressEvent( QMouseEvent* ) override;
+    void mouseMoveEvent( QMouseEvent* ) override;
+    void mouseReleaseEvent( QMouseEvent* ) override;
+
+  private:
+    void updatePosition( QMouseEvent* );
+
+    class PrivateData;
+    std::unique_ptr< PrivateData > m_data;
+};
+
+#endif

--- a/src/dialogs/QskColorPickerSkinlet.cpp
+++ b/src/dialogs/QskColorPickerSkinlet.cpp
@@ -22,10 +22,11 @@ namespace
         {
         }
 
-        void paint( QPainter* p, const QSize&, const void* nodeData ) override
+        void paint( QPainter* p, const QSize& size, const void* nodeData ) override
         {
             const Q* q = static_cast< const Q* >( nodeData );
-            p->drawImage( QPointF( 0, 0 ), q->image() );
+            const auto image = q->image().scaled( size );
+            p->drawImage( QPointF( 0, 0 ), image );
         }
 
         void updateNode( QQuickWindow* window, const QRectF& rect, const Q* q )

--- a/src/dialogs/QskColorPickerSkinlet.cpp
+++ b/src/dialogs/QskColorPickerSkinlet.cpp
@@ -1,0 +1,181 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskColorPickerSkinlet.h"
+#include "QskColorPicker.h"
+
+#include "QskSGNode.h"
+#include "QskPaintedNode.h"
+
+#include <QPainter>
+
+using Q = QskColorPicker;
+
+namespace
+{
+    class ColorPaneNode : public QskPaintedNode
+    {
+      public:
+        ColorPaneNode()
+        {
+        }
+
+        void paint( QPainter* p, const QSize& size, const void* nodeData ) override
+        {
+            if(  m_image.size() != size )
+            {
+                m_image = QImage( size.width(), size.height(), QImage::Format_RGB32 );
+            }
+
+            QColor color;
+            float h, s;
+            const float v = *reinterpret_cast< const int* >( nodeData ) / 255.0;
+
+            for( int x = 0; x < m_image.width(); x++ )
+            {
+                h = ( float ) x / m_image.width();
+
+                for( int y = 0; y < m_image.height(); y++ )
+                {
+                    s = 1.0 - ( float ) y / m_image.height();
+                    color.setHsvF( h, s, v );
+                    m_image.setPixel( x, y, color.rgb() );
+                }
+            }
+
+            p->drawImage( QPointF( 0, 0 ), m_image );
+        }
+
+        void updateNode( QQuickWindow* window, const QRectF& rect, int value )
+        {
+            update( window, rect, QSizeF(), &value );
+        }
+
+        QColor selectedColor( const QPointF& p ) const
+        {
+            return m_image.pixelColor( p.toPoint() );
+        }
+
+      protected:
+        QskHashValue hash( const void* nodeData ) const override
+        {
+            const auto* value = reinterpret_cast< const int* >( nodeData );
+            return *value;
+        }
+
+      private:
+        QImage m_image;
+    };
+}
+
+class QskColorPickerSkinlet::PrivateData
+{
+  public:
+    QColor selectedColor;
+    ColorPaneNode* colorPaneNode = nullptr;
+};
+
+QskColorPickerSkinlet::QskColorPickerSkinlet( QskSkin* skin )
+    : Inherited( skin )
+    , m_data( new PrivateData )
+{
+    setNodeRoles( { PanelRole, ColorPaneRole, SelectorRole } );
+}
+
+QskColorPickerSkinlet::~QskColorPickerSkinlet() = default;
+
+QSGNode* QskColorPickerSkinlet::updateSubNode(
+    const QskSkinnable* skinnable, quint8 nodeRole, QSGNode* node ) const
+{
+    const auto q = static_cast< const Q* >( skinnable );
+
+    switch ( nodeRole )
+    {
+        case PanelRole:
+        {
+            return updateBoxNode( skinnable, node, Q::Panel );
+        }
+        case ColorPaneRole:
+        {
+            return updateColorPaneNode( q, node );
+        }
+        case SelectorRole:
+        {
+            auto* n = updateBoxNode( skinnable, node, Q::Selector );
+            updateSelectedColor( q );
+            return n;
+        }
+    }
+
+    return Inherited::updateSubNode( skinnable, nodeRole, node );
+}
+
+QRectF QskColorPickerSkinlet::subControlRect(
+    const QskSkinnable* skinnable, const QRectF& contentsRect,
+    QskAspect::Subcontrol subControl ) const
+{
+    const auto q = static_cast< const Q* >( skinnable );
+
+    if( subControl == Q::Panel || subControl == Q::ColorPane )
+    {
+        return contentsRect;
+    }
+
+    if( subControl == Q::Selector )
+    {
+        const auto size = q->strutSizeHint( Q::Selector );
+        const auto x = q->positionHint( Q::Selector | QskAspect::Horizontal );
+        const auto y = q->positionHint( Q::Selector | QskAspect::Vertical );
+
+        QRectF r( { x - size.width() / 2.0, y - size.height() / 2.0 }, size );
+        return r;
+    }
+
+    return Inherited::subControlRect( skinnable, contentsRect, subControl );
+}
+
+QColor QskColorPickerSkinlet::selectedColor() const
+{
+    return m_data->selectedColor;
+}
+
+QSGNode* QskColorPickerSkinlet::updateColorPaneNode(
+    const QskColorPicker* q, QSGNode* node ) const
+{
+    m_data->colorPaneNode = QskSGNode::ensureNode< ColorPaneNode >( node );
+
+    const auto rect = q->subControlRect( Q::ColorPane );
+    m_data->colorPaneNode->updateNode( q->window(), rect, q->value() );
+
+    updateSelectedColor( q );
+
+    return m_data->colorPaneNode;
+}
+
+QPointF QskColorPickerSkinlet::selectorPos( const Q* q ) const
+{
+    const auto x = q->positionHint( Q::Selector | QskAspect::Horizontal );
+    const auto y = q->positionHint( Q::Selector | QskAspect::Vertical );
+
+    QPointF p( x, y );
+
+    const auto rect = q->subControlRect( Q::ColorPane );
+
+    p.rx() = qBound( rect.x(), p.x(), rect.right() );
+    p.ry() = qBound( rect.y(), p.y(), rect.bottom() );
+
+    return p;
+}
+
+void QskColorPickerSkinlet::updateSelectedColor( const Q* q ) const
+{
+    const auto color = m_data->colorPaneNode->selectedColor( selectorPos( q ) );
+    m_data->selectedColor = color;
+
+    auto* e = new QEvent( static_cast< QEvent::Type >( q->colorChangedEventType() ) );
+    QCoreApplication::postEvent( const_cast< Q* >( q ), e );
+}
+
+#include "moc_QskColorPickerSkinlet.cpp"

--- a/src/dialogs/QskColorPickerSkinlet.cpp
+++ b/src/dialogs/QskColorPickerSkinlet.cpp
@@ -18,10 +18,6 @@ namespace
     class ColorPaneNode : public QskPaintedNode
     {
       public:
-        ColorPaneNode()
-        {
-        }
-
         void paint( QPainter* p, const QSize& size, const void* nodeData ) override
         {
             const Q* q = static_cast< const Q* >( nodeData );

--- a/src/dialogs/QskColorPickerSkinlet.h
+++ b/src/dialogs/QskColorPickerSkinlet.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#ifndef QSK_COLOR_PICKER_SKINLET_H
+#define QSK_COLOR_PICKER_SKINLET_H
+
+#include "QskSkinlet.h"
+
+class QskColorPicker;
+
+class QskColorPickerSkinlet : public QskSkinlet
+{
+    Q_GADGET
+
+    using Inherited = QskSkinlet;
+
+  public:
+    enum NodeRole : quint8
+    {
+        PanelRole,
+        ColorPaneRole,
+        SelectorRole,
+
+        RoleCount
+    };
+
+    Q_INVOKABLE QskColorPickerSkinlet( QskSkin* = nullptr );
+    ~QskColorPickerSkinlet() override;
+
+    QRectF subControlRect( const QskSkinnable*,
+        const QRectF&, QskAspect::Subcontrol ) const override;
+
+    QColor selectedColor() const;
+
+  protected:
+    QSGNode* updateSubNode( const QskSkinnable*,
+        quint8 nodeRole, QSGNode* ) const override;
+
+    QSGNode* updateColorPaneNode( const QskColorPicker*, QSGNode* ) const;
+
+  private:
+    QRectF cursorRect( const QskSkinnable*, const QRectF&, int index ) const;
+    QPointF selectorPos( const QskColorPicker* ) const;
+    void updateSelectedColor( const QskColorPicker* ) const;
+
+    class PrivateData;
+    std::unique_ptr< PrivateData > m_data;
+};
+
+#endif

--- a/src/dialogs/QskColorPickerSkinlet.h
+++ b/src/dialogs/QskColorPickerSkinlet.h
@@ -32,15 +32,13 @@ class QskColorPickerSkinlet : public QskSkinlet
     QRectF subControlRect( const QskSkinnable*,
         const QRectF&, QskAspect::Subcontrol ) const override;
 
-    QColor selectedColor() const;
-
   protected:
     QSGNode* updateSubNode( const QskSkinnable*,
         quint8 nodeRole, QSGNode* ) const override;
 
+  private:
     QSGNode* updateColorPaneNode( const QskColorPicker*, QSGNode* ) const;
 
-  private:
     QRectF cursorRect( const QskSkinnable*, const QRectF&, int index ) const;
 };
 

--- a/src/dialogs/QskColorPickerSkinlet.h
+++ b/src/dialogs/QskColorPickerSkinlet.h
@@ -42,11 +42,6 @@ class QskColorPickerSkinlet : public QskSkinlet
 
   private:
     QRectF cursorRect( const QskSkinnable*, const QRectF&, int index ) const;
-    QPointF selectorPos( const QskColorPicker* ) const;
-    void updateSelectedColor( const QskColorPicker* ) const;
-
-    class PrivateData;
-    std::unique_ptr< PrivateData > m_data;
 };
 
 #endif

--- a/src/dialogs/QskColorSelectionWindow.cpp
+++ b/src/dialogs/QskColorSelectionWindow.cpp
@@ -1,0 +1,128 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskColorSelectionWindow.h"
+
+#include "QskBoxBorderColors.h"
+#include "QskBoxBorderMetrics.h"
+#include "QskBoxShapeMetrics.h"
+#include "QskColorPicker.h"
+#include "QskComboBox.h"
+#include "QskGridBox.h"
+#include "QskLinearBox.h"
+#include "QskSlider.h"
+#include "QskTextField.h"
+#include "QskTextLabel.h"
+
+template< typename W >
+class QskColorSelectionWindow< W >::PrivateData
+{
+  public:
+    QskColorPicker* colorPicker;
+};
+
+template< typename W >
+QskColorSelectionWindow< W >::QskColorSelectionWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction )
+        : Inherited( parent, title, actions, defaultAction )
+        , m_data( new PrivateData )
+{
+    auto* outerBox = new QskLinearBox( Qt::Vertical );
+    outerBox->setMargins( 20 );
+    outerBox->setSpacing( 20 );
+#if 1
+    outerBox->setFixedSize( 350, 500 );
+#endif
+    auto* upperBox = new QskLinearBox( Qt::Horizontal, outerBox );
+    upperBox->setSizePolicy( Qt::Vertical, QskSizePolicy::Expanding );
+    upperBox->setSpacing( 12 );
+
+    m_data->colorPicker = new QskColorPicker( upperBox );
+    m_data->colorPicker->setStrutSizeHint( QskColorPicker::Selector, { 18, 18 } );
+    m_data->colorPicker->setBoxShapeHint( QskColorPicker::Selector, { 100, Qt::RelativeSize } );
+    m_data->colorPicker->setBoxBorderMetricsHint( QskColorPicker::Selector, 2 );
+    m_data->colorPicker->setBoxBorderColorsHint( QskColorPicker::Selector, Qt::black );
+    m_data->colorPicker->setGradientHint( QskColorPicker::Selector, Qt::transparent );
+
+    auto* outputBox = new QskBox( upperBox );
+    outputBox->setPanel( true );
+
+    QObject::connect( m_data->colorPicker, &QskColorPicker::selectedColorChanged,
+        this, [this, outputBox]()
+    {
+        const auto c = m_data->colorPicker->selectedColor();
+        outputBox->setGradientHint( QskBox::Panel, c );
+    } );
+
+    upperBox->setStretchFactor( m_data->colorPicker, 9 );
+    upperBox->setStretchFactor( outputBox, 1 );
+
+
+    auto* valueSlider = new QskSlider( outerBox );
+    valueSlider->setBoundaries( 0, 1 );
+    valueSlider->setValue( m_data->colorPicker->value() );
+
+    QskGradient g( Qt::black, Qt::white );
+    g.setLinearDirection( Qt::Horizontal );
+    valueSlider->setGradientHint( QskSlider::Groove, g );
+    valueSlider->setGradientHint( QskSlider::Fill, Qt::transparent );
+    valueSlider->setGradientHint( QskSlider::Handle, Qt::black );
+
+    QObject::connect( valueSlider, &QskSlider::valueChanged,
+        m_data->colorPicker, &QskColorPicker::setValueAsRatio );
+
+
+    auto* gridBox = new QskGridBox( outerBox );
+    gridBox->setSizePolicy( Qt::Vertical, QskSizePolicy::Preferred );
+
+    auto* menu = new QskComboBox( gridBox );
+    menu->addOption( QUrl(), "RGB" );
+    menu->setCurrentIndex( 0 );
+    gridBox->addItem( menu, 0, 0 );
+
+    auto* rgbValue = new QskTextField( gridBox );
+    rgbValue->setReadOnly( true );
+    gridBox->addItem( rgbValue, 0, 2 );
+
+    auto* redValue = new QskTextField( gridBox );
+    redValue->setReadOnly( true );
+    gridBox->addItem( redValue, 1, 0 );
+    gridBox->addItem( new QskTextLabel( "Red", gridBox ), 1, 1 );
+
+    auto* greenValue = new QskTextField( gridBox );
+    greenValue->setReadOnly( true );
+    gridBox->addItem( greenValue, 2, 0 );
+    gridBox->addItem( new QskTextLabel( "Green", gridBox ), 2, 1 );
+
+    auto* blueValue = new QskTextField( gridBox );
+    blueValue->setReadOnly( true );
+    gridBox->addItem( blueValue, 3, 0 );
+    gridBox->addItem( new QskTextLabel( "Blue", gridBox ), 3, 1 );
+
+    QObject::connect( m_data->colorPicker, &QskColorPicker::selectedColorChanged,
+        this, [this, rgbValue, redValue, greenValue, blueValue]()
+    {
+            const auto c = m_data->colorPicker->selectedColor();
+            rgbValue->setText( c.name() );
+
+            redValue->setText( QString::number( c.red() ) );
+            greenValue->setText( QString::number( c.green() ) );
+            blueValue->setText( QString::number( c.blue() ) );
+    } );
+
+    Inherited::setContentItem( outerBox );
+}
+
+template< typename W >
+QskColorSelectionWindow< W >::~QskColorSelectionWindow() = default;
+
+template< typename W >
+QColor QskColorSelectionWindow< W >::selectedColor() const
+{
+    return m_data->colorPicker->selectedColor();
+}
+
+template class QskColorSelectionWindow< QskDialogWindow >;
+template class QskColorSelectionWindow< QskDialogSubWindow >;

--- a/src/dialogs/QskColorSelectionWindow.h
+++ b/src/dialogs/QskColorSelectionWindow.h
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#ifndef QSK_COLOR_SELECTION_WINDODW_H
+#define QSK_COLOR_SELECTION_WINDODW_H
+
+#include "QskWindowOrSubWindow.h"
+
+class QskColorPicker;
+
+template< typename W >
+class QskColorSelectionWindow : public QskWindowOrSubWindow< W >
+{
+    using Inherited = QskWindowOrSubWindow< W >;
+
+  public:
+
+    QskColorSelectionWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction );
+    ~QskColorSelectionWindow();
+
+    QColor selectedColor() const;
+
+  private:
+    class PrivateData;
+    std::unique_ptr< PrivateData > m_data;
+};
+
+#endif

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -272,14 +272,15 @@ namespace
             QObject::connect( m_model, &QFileSystemModel::directoryLoaded,
                 this, &FileSelectionWindow< W >::loadContents );
 
-            QObject::connect( m_model, &QFileSystemModel::rootPathChanged,
-                this, &FileSelectionWindow< W >::loadContents );
-
             QObject::connect( m_listBox, &QskSimpleListBox::selectedEntryChanged,
                 this, [this]( const QString& path )
             {
                 QFileInfo fi( m_model->rootPath(), path );
-                m_model->setRootPath( fi.absoluteFilePath() );
+
+                if( fi.isDir() )
+                {
+                    m_model->setRootPath( fi.absoluteFilePath() );
+                }
             });
         }
 

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -206,20 +206,21 @@ namespace
             : QskListView( parent )
             , m_model( new QFileSystemModel( this ) )
         {
-            connect( m_model, &QFileSystemModel::directoryLoaded, this, [this]()
+            const auto defaultWidth = 50;
+
+            connect( m_model, &QFileSystemModel::directoryLoaded, this, [this, defaultWidth]()
             {
-                m_columnWidths.fill( 0 );
+                m_columnWidths.fill( defaultWidth );
                 updateScrollableSize();
                 setScrollPos( { 0, 0 } );
                 setSelectedRow( -1 );
-                update();
             });
 
             m_model->setFilter( filters );
             m_model->setRootPath( {} ); // invalidate to make sure to get an update
             m_model->setRootPath( directory );
 
-            m_columnWidths.fill( 0, m_model->columnCount() );
+            m_columnWidths.fill( defaultWidth, m_model->columnCount() );
         }
 
         virtual int rowCount() const override
@@ -239,7 +240,9 @@ namespace
             auto w = m_columnWidths.at( col );
 
             if( col == 0 )
-                w = qMax( 250, w );
+            {
+                w = qMax( 250, w ); // min width for the name
+            }
 
             return w + 15; // spacing
         }

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -16,9 +16,9 @@
 #include "QskBoxBorderMetrics.h"
 #include "QskColorSelectionWindow.h"
 #include "QskFileSelectionWindow.h"
+#include "QskFontSelectionWindow.h"
 #include "QskEvent.h"
 #include "QskFunctions.h"
-#include "QskListView.h"
 
 #include "QskFocusIndicator.h"
 
@@ -245,6 +245,17 @@ static QColor qskSelectColor( QskColorSelectionWindow< W >& window )
     return selectedColor;
 }
 
+template< typename W >
+static QFont qskSelectFont( QskFontSelectionWindow< W >& window )
+{
+    QFont selectedFont = window.selectedFont();
+
+    if( window.exec() == QskDialog::Accepted )
+        selectedFont = window.selectedFont();
+
+    return selectedFont;
+}
+
 class QskDialog::PrivateData
 {
   public:
@@ -447,6 +458,34 @@ QColor QskDialog::selectColor( const QString& title ) const
     QskColorSelectionWindow< QskDialogWindow > window( m_data->transientParent, title,
         actions, defaultAction );
     return qskSelectColor< QskDialogWindow >( window );
+}
+
+QFont QskDialog::selectFont( const QString& title ) const
+{
+#if 1
+    // should be parameters
+    const auto actions = QskDialog::Ok | QskDialog::Cancel;
+    const auto defaultAction = QskDialog::Ok;
+#endif
+
+    if ( m_data->policy == EmbeddedBox )
+    {
+        auto quickWindow = qobject_cast< QQuickWindow* >( m_data->transientParent );
+
+        if ( quickWindow == nullptr )
+            quickWindow = qskSomeQuickWindow();
+
+        if ( quickWindow )
+        {
+            QskFontSelectionWindow< QskDialogSubWindow > window( quickWindow, title,
+                actions, defaultAction );
+            return qskSelectFont< QskDialogSubWindow >( window );
+        }
+    }
+
+    QskFontSelectionWindow< QskDialogWindow > window( m_data->transientParent, title,
+        actions, defaultAction );
+    return qskSelectFont< QskDialogWindow >( window );
 }
 
 QskDialog::ActionRole QskDialog::actionRole( Action action )

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -479,7 +479,7 @@ namespace
             outerBox->setMargins( 20 );
             outerBox->setSpacing( 20 );
 #if 1
-            outerBox->setFixedSize( 700, 500 );
+            outerBox->setFixedSize( 500, 500 );
 #endif
             auto* upperBox = new QskLinearBox( Qt::Horizontal, outerBox );
             upperBox->setSpacing( 12 );

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -12,22 +12,15 @@
 #include "QskSelectionSubWindow.h"
 #include "QskSelectionWindow.h"
 
-#include "QskBoxBorderColors.h"
-#include "QskBoxBorderMetrics.h"
 #include "QskColorSelectionWindow.h"
 #include "QskFileSelectionWindow.h"
 #include "QskFontSelectionWindow.h"
-#include "QskEvent.h"
-#include "QskFunctions.h"
 
 #include "QskFocusIndicator.h"
 
-#include <qfontmetrics.h>
-#include <qfilesystemmodel.h>
 #include <qguiapplication.h>
 #include <qpointer.h>
 #include <qquickwindow.h>
-#include <qtimer.h>
 
 #include <qpa/qplatformdialoghelper.h>
 
@@ -63,10 +56,6 @@ static QskDialog::DialogCode qskExec( QskDialogWindow* dialogWindow )
 #endif
 
     return dialogWindow->exec();
-}
-
-namespace
-{
 }
 
 static QQuickWindow* qskSomeQuickWindow()
@@ -123,7 +112,6 @@ static void qskSetupWindow(
     window->setModality( transientParent ? Qt::WindowModal : Qt::ApplicationModal );
 
     const QSize size = window->sizeConstraint();
-    qDebug() << "sc:" << size;
 
     if ( window->parent() )
     {

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -109,13 +109,19 @@ namespace
                 setGeometry( r );
             }
 
-            if ( size.isValid() )
+            auto adjustSize = [this]()
             {
-                setFlags( flags() | Qt::MSWindowsFixedSizeDialogHint );
-                setFixedSize( size );
-            }
+                const QSize size = sizeConstraint();
 
-            setModality( Qt::ApplicationModal );
+                if ( size.isValid() )
+                {
+                    setFlags( flags() | Qt::MSWindowsFixedSizeDialogHint );
+                    setFixedSize( size );
+                }
+            };
+
+            connect( contentItem(), &QQuickItem::widthChanged, this, adjustSize );
+            connect( contentItem(), &QQuickItem::heightChanged, this, adjustSize );
         }
 
         QskDialog::DialogCode exec()

--- a/src/dialogs/QskDialog.cpp
+++ b/src/dialogs/QskDialog.cpp
@@ -18,12 +18,16 @@
 #include "QskBoxBorderMetrics.h"
 #include "QskBoxShapeMetrics.h"
 #include "QskColorPicker.h"
+#include "QskComboBox.h"
 #include "QskEvent.h"
 #include "QskFunctions.h"
+#include "QskGridBox.h"
 #include "QskListView.h"
 #include "QskPushButton.h"
 #include "QskScrollArea.h"
 #include "QskSlider.h"
+#include "QskTextField.h"
+#include "QskTextLabel.h"
 
 #include "QskFocusIndicator.h"
 
@@ -479,9 +483,10 @@ namespace
             outerBox->setMargins( 20 );
             outerBox->setSpacing( 20 );
 #if 1
-            outerBox->setFixedSize( 500, 500 );
+            outerBox->setFixedSize( 350, 500 );
 #endif
             auto* upperBox = new QskLinearBox( Qt::Horizontal, outerBox );
+            upperBox->setSizePolicy( Qt::Vertical, QskSizePolicy::Expanding );
             upperBox->setSpacing( 12 );
 
             m_picker = new QskColorPicker( upperBox );
@@ -517,6 +522,45 @@ namespace
 
             QObject::connect( valueSlider, &QskSlider::valueChanged,
                 m_picker, &QskColorPicker::setValueAsRatio );
+
+
+            auto* gridBox = new QskGridBox( outerBox );
+            gridBox->setSizePolicy( Qt::Vertical, QskSizePolicy::Preferred );
+
+            auto* menu = new QskComboBox( gridBox );
+            menu->addOption( QUrl(), "RGB" );
+            menu->setCurrentIndex( 0 );
+            gridBox->addItem( menu, 0, 0 );
+
+            auto* rgbValue = new QskTextField( gridBox );
+            rgbValue->setReadOnly( true );
+            gridBox->addItem( rgbValue, 0, 2 );
+
+            auto* redValue = new QskTextField( gridBox );
+            redValue->setReadOnly( true );
+            gridBox->addItem( redValue, 1, 0 );
+            gridBox->addItem( new QskTextLabel( "Red", gridBox ), 1, 1 );
+
+            auto* greenValue = new QskTextField( gridBox );
+            greenValue->setReadOnly( true );
+            gridBox->addItem( greenValue, 2, 0 );
+            gridBox->addItem( new QskTextLabel( "Green", gridBox ), 2, 1 );
+
+            auto* blueValue = new QskTextField( gridBox );
+            blueValue->setReadOnly( true );
+            gridBox->addItem( blueValue, 3, 0 );
+            gridBox->addItem( new QskTextLabel( "Blue", gridBox ), 3, 1 );
+
+            QObject::connect( m_picker, &QskColorPicker::selectedColorChanged,
+                this, [this, rgbValue, redValue, greenValue, blueValue]()
+            {
+                    const auto c = m_picker->selectedColor();
+                    rgbValue->setText( c.name() );
+
+                    redValue->setText( QString::number( c.red() ) );
+                    greenValue->setText( QString::number( c.green() ) );
+                    blueValue->setText( QString::number( c.blue() ) );
+            } );
 
             Inherited::setContentItem( outerBox );
         }

--- a/src/dialogs/QskDialog.h
+++ b/src/dialogs/QskDialog.h
@@ -8,7 +8,7 @@
 
 #include "QskGlobal.h"
 
-#include <qrgb.h>
+#include <qcolor.h>
 #include <qobject.h>
 #include <memory>
 

--- a/src/dialogs/QskDialog.h
+++ b/src/dialogs/QskDialog.h
@@ -8,6 +8,7 @@
 
 #include "QskGlobal.h"
 
+#include <qrgb.h>
 #include <qobject.h>
 #include <memory>
 
@@ -135,6 +136,8 @@ class QSK_EXPORT QskDialog : public QObject
 
     Q_INVOKABLE QString selectDirectory( const QString& title,
         const QString& directory ) const;
+
+    Q_INVOKABLE QColor selectColor( const QString& title ) const;
 
     static ActionRole actionRole( Action action );
 

--- a/src/dialogs/QskDialog.h
+++ b/src/dialogs/QskDialog.h
@@ -133,6 +133,9 @@ class QSK_EXPORT QskDialog : public QObject
     Q_INVOKABLE QString selectFile( const QString& title,
         const QString& directory ) const;
 
+    Q_INVOKABLE QString selectDirectory( const QString& title,
+        const QString& directory ) const;
+
     static ActionRole actionRole( Action action );
 
   Q_SIGNALS:

--- a/src/dialogs/QskDialog.h
+++ b/src/dialogs/QskDialog.h
@@ -139,6 +139,8 @@ class QSK_EXPORT QskDialog : public QObject
 
     Q_INVOKABLE QColor selectColor( const QString& title ) const;
 
+    Q_INVOKABLE QFont selectFont( const QString& title ) const;
+
     static ActionRole actionRole( Action action );
 
   Q_SIGNALS:

--- a/src/dialogs/QskDialog.h
+++ b/src/dialogs/QskDialog.h
@@ -130,6 +130,9 @@ class QSK_EXPORT QskDialog : public QObject
     Q_INVOKABLE QString select( const QString& title,
         const QStringList& entries, int selectedRow = 0 ) const;
 
+    Q_INVOKABLE QString selectFile( const QString& title,
+        const QString& directory ) const;
+
     static ActionRole actionRole( Action action );
 
   Q_SIGNALS:

--- a/src/dialogs/QskFileSelectionWindow.cpp
+++ b/src/dialogs/QskFileSelectionWindow.cpp
@@ -1,0 +1,320 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskFileSelectionWindow.h"
+
+#include "QskEvent.h"
+#include "QskFunctions.h"
+#include "QskLinearBox.h"
+#include "QskListView.h"
+#include "QskScrollArea.h"
+#include "QskPushButton.h"
+
+#include <QFileSystemModel>
+
+// copied from QskListView.cpp:
+static inline int qskRowAt( const QskListView* listView, const QPointF& pos )
+{
+    const auto rect = listView->viewContentsRect();
+    if ( rect.contains( pos ) )
+    {
+        const auto y = pos.y() - rect.top() + listView->scrollPos().y();
+
+        const int row = y / listView->rowHeight();
+        if ( row >= 0 && row < listView->rowCount() )
+            return row;
+    }
+
+    return -1;
+}
+
+// copied from QskGestureRecognizer.cpp:
+static QMouseEvent* qskClonedMouseEvent( const QMouseEvent* event )
+{
+    QMouseEvent* clonedEvent;
+
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+    clonedEvent = QQuickWindowPrivate::cloneMouseEvent(
+        const_cast< QMouseEvent* >( event ), nullptr );
+#else
+    clonedEvent = event->clone();
+#endif
+    clonedEvent->setAccepted( false );
+
+    return clonedEvent;
+}
+
+namespace
+{
+    class FileSystemView : public QskListView
+    {
+        using Inherited = QskListView;
+
+      public:
+        FileSystemView( const QString& directory, QDir::Filters filters, QQuickItem* parent = nullptr )
+            : QskListView( parent )
+            , m_model( new QFileSystemModel( this ) )
+        {
+            const auto defaultWidth = 50;
+
+            connect( m_model, &QFileSystemModel::directoryLoaded, this, [this]()
+            {
+                m_columnWidths.fill( defaultWidth );
+                updateScrollableSize();
+                setScrollPos( { 0, 0 } );
+                setSelectedRow( -1 );
+            });
+
+            m_model->setFilter( filters );
+            m_model->setRootPath( {} ); // invalidate to make sure to get an update
+            m_model->setRootPath( directory );
+
+            m_columnWidths.fill( defaultWidth, m_model->columnCount() );
+        }
+
+        virtual int rowCount() const override
+        {
+            const auto index = m_model->index( m_model->rootPath() );
+            return m_model->rowCount( index );
+        }
+
+        virtual int columnCount() const override
+        {
+            const auto index = m_model->index( m_model->rootPath() );
+            return m_model->columnCount( index );
+        }
+
+        virtual qreal columnWidth( int col ) const override
+        {
+            auto w = m_columnWidths.at( col );
+
+            if( col == 0 )
+            {
+                w = qMax( 250, w ); // min width for the name
+            }
+
+            return w + 15; // spacing
+        }
+
+        virtual qreal rowHeight() const override
+        {
+            const auto hint = strutSizeHint( Cell );
+            const auto padding = paddingHint( Cell );
+
+            qreal h = effectiveFontHeight( Text );
+            h += padding.top() + padding.bottom();
+
+            return qMax( h, hint.height() );
+        }
+
+        virtual QVariant valueAt( int row, int col ) const override
+        {
+            const auto rootIndex = m_model->index( m_model->rootPath() );
+
+            const auto index = m_model->index( row, col, rootIndex );
+            const auto v = m_model->data( index );
+
+            const auto w = qskHorizontalAdvance( effectiveFont( Text ), v.toString() );
+
+            if( w > m_columnWidths.at( col ) )
+            {
+                m_columnWidths[ col ] = w;
+            }
+
+            return v;
+        }
+
+        QFileSystemModel* model()
+        {
+            return m_model;
+        }
+
+      protected:
+
+        void mousePressEvent( QMouseEvent* event ) override
+        {
+            if( m_doubleClickEvent && m_doubleClickEvent->timestamp() == event->timestamp() )
+            {
+                // do not select rows from double click mouse events
+                m_doubleClickEvent = nullptr;
+            }
+            else
+            {
+                Inherited::mousePressEvent( event );
+            }
+        }
+
+        void mouseDoubleClickEvent( QMouseEvent* event ) override
+        {
+            m_doubleClickEvent = qskClonedMouseEvent( event );
+
+            const int row = qskRowAt( this, qskMousePosition( event ) );
+            const auto path = valueAt( row, 0 ).toString();
+
+            QFileInfo fi( m_model->rootPath(), path );
+
+            if( fi.isDir() )
+            {
+                m_model->setRootPath( fi.absoluteFilePath() );
+            }
+
+            Inherited::mouseDoubleClickEvent( event );
+        }
+
+      private:
+        QFileSystemModel* const m_model;
+        mutable QVector< int > m_columnWidths;
+        QMouseEvent* m_doubleClickEvent = nullptr;
+    };
+}
+
+template< typename W >
+class QskFileSelectionWindow< W >::PrivateData
+{
+  public:
+    QskScrollArea* headerScrollArea;
+    QskLinearBox* headerBox;
+    QVector< QskPushButton* > breadcrumbsButtons;
+
+    FileSystemView* fileView;
+};
+
+template< typename W >
+QskFileSelectionWindow< W >::QskFileSelectionWindow( QObject* parent, const QString& title,
+    QskDialog::Actions actions, QskDialog::Action defaultAction,
+    const QString& directory, QDir::Filters filters )
+    : QskWindowOrSubWindow< W >( parent, title, actions, defaultAction )
+    , m_data( new PrivateData )
+{
+    auto* outerBox = new QskLinearBox( Qt::Vertical );
+    outerBox->setMargins( 20 );
+    outerBox->setSpacing( 20 );
+#if 1
+    outerBox->setFixedSize( 700, 500 );
+#endif
+    setupHeader( outerBox );
+    setupFileSystemView( directory, filters, outerBox );
+
+    updateHeader( directory );
+
+    Inherited::setContentItem( outerBox );
+}
+
+template< typename W >
+QskFileSelectionWindow< W >::~QskFileSelectionWindow() = default;
+
+template< typename W >
+QString QskFileSelectionWindow< W >::selectedPath() const
+{
+    if( m_data->fileView->selectedRow() != -1 )
+    {
+        const auto path = m_data->fileView->valueAt( m_data->fileView->selectedRow(), 0 ).toString();
+        QFileInfo fi( m_data->fileView->model()->rootPath(), path );
+        return fi.absoluteFilePath();
+    }
+
+    return {};
+}
+
+template< typename W >
+void QskFileSelectionWindow< W >::setupHeader( QQuickItem* parentItem )
+{
+    m_data->headerScrollArea = new QskScrollArea( parentItem );
+    m_data->headerScrollArea->setSizePolicy( Qt::Vertical, QskSizePolicy::Fixed );
+    m_data->headerScrollArea->setFlickableOrientations( Qt::Horizontal );
+
+    m_data->headerBox = new QskLinearBox( Qt::Horizontal, m_data->headerScrollArea );
+    m_data->headerScrollArea->setScrolledItem( m_data->headerBox );
+}
+
+static QStringList splitPath( const QString& path )
+{
+    const auto cleanPath = QDir::cleanPath( path );
+
+    QDir dir( cleanPath );
+
+    QStringList result;
+
+    do
+    {
+        if( dir != QDir::root() )
+        {
+            result.prepend( dir.absolutePath() );
+        }
+    }
+    while( dir.cdUp() );
+
+    return result;
+}
+
+template< typename W >
+void QskFileSelectionWindow< W >::updateHeader( const QString& path )
+{
+    const auto dirPaths = ::splitPath( path );
+
+    for( int i = 0; i < dirPaths.count(); ++i )
+    {
+        QskPushButton* b;
+
+        if( m_data->breadcrumbsButtons.count() <= i )
+        {
+            b = new QskPushButton( m_data->headerBox );
+            b->setStrutSizeHint( QskPushButton::Panel, { -1, -1 } );
+            m_data->breadcrumbsButtons.append( b );
+        }
+        else
+        {
+            b = m_data->breadcrumbsButtons.at( i );
+            b->disconnect();
+        }
+
+        QFileInfo fi( dirPaths.at( i ) );
+        b->setText( fi.baseName() );
+
+        QObject::connect( b, &QskPushButton::clicked, this, [this, fi]()
+        {
+            m_data->fileView->model()->setRootPath( fi.filePath() );
+        });
+    }
+
+    for( int i = dirPaths.count(); i < m_data->breadcrumbsButtons.count(); i++ )
+    {
+        m_data->breadcrumbsButtons.at( i )->deleteLater();
+    }
+
+    m_data->breadcrumbsButtons.remove( dirPaths.count(), m_data->breadcrumbsButtons.count() - dirPaths.count() );
+
+    if( !m_data->breadcrumbsButtons.isEmpty() )
+    {
+        auto* b = m_data->breadcrumbsButtons.last();
+
+        // button might just have been created and not be layed out yet:
+        QObject::connect( b, &QskPushButton::widthChanged, this, [this, b]()
+        {
+            m_data->headerScrollArea->ensureItemVisible( b );
+        } );
+    }
+}
+
+template< typename W >
+void QskFileSelectionWindow< W >::setupFileSystemView( const QString& directory, QDir::Filters filters, QQuickItem* parentItem )
+{
+    m_data->fileView = new FileSystemView( directory, filters, parentItem );
+
+    QObject::connect( m_data->fileView->model(), &QFileSystemModel::rootPathChanged,
+        this, &QskFileSelectionWindow< W >::updateHeader );
+
+    QObject::connect( m_data->fileView, &QskListView::selectedRowChanged, this, [this]()
+    {
+        if( m_data->fileView->model()->filter() & QDir::Files )
+        {
+            QFileInfo fi( selectedPath() );
+            W::defaultButton()->setEnabled( !fi.isDir() );
+        }
+    } );
+}
+
+template class QskFileSelectionWindow< QskDialogWindow >;
+template class QskFileSelectionWindow< QskDialogSubWindow >;

--- a/src/dialogs/QskFileSelectionWindow.h
+++ b/src/dialogs/QskFileSelectionWindow.h
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#ifndef QSK_FILE_SELECTION_WINDODW_H
+#define QSK_FILE_SELECTION_WINDODW_H
+
+#include "QskWindowOrSubWindow.h"
+
+#include <QDir>
+
+template< typename W >
+class QskFileSelectionWindow : public QskWindowOrSubWindow< W >
+{
+    using Inherited = QskWindowOrSubWindow< W >;
+
+  public:
+
+    QskFileSelectionWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction,
+        const QString& directory, QDir::Filters filters );
+    ~QskFileSelectionWindow();
+
+    QString selectedPath() const;
+
+  private:
+    void setupHeader( QQuickItem* parentItem );
+
+    static QStringList splitPath( const QString& path );
+
+    void updateHeader( const QString& path );
+
+    void setupFileSystemView( const QString& directory, QDir::Filters filters, QQuickItem* parentItem );
+
+  private:
+    class PrivateData;
+    std::unique_ptr< PrivateData >m_data;
+};
+
+#endif

--- a/src/dialogs/QskFontSelectionWindow.cpp
+++ b/src/dialogs/QskFontSelectionWindow.cpp
@@ -1,0 +1,160 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskFontSelectionWindow.h"
+
+#include "QskFontRole.h"
+#include "QskGridBox.h"
+#include "QskLinearBox.h"
+#include "QskSimpleListBox.h"
+#include "QskTextLabel.h"
+
+#include <QFontDatabase>
+
+template< typename W >
+class QskFontSelectionWindow< W >::PrivateData
+{
+  public:
+    QFont selectedFont;
+
+    QskSimpleListBox* familyView;
+    QskSimpleListBox* styleView;
+    QskSimpleListBox* sizeView;
+
+    QskTextLabel* outputLabel;
+};
+
+template< typename W >
+QskFontSelectionWindow< W >::QskFontSelectionWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction )
+        : Inherited( parent, title, actions, defaultAction )
+        , m_data( new PrivateData )
+{
+    auto* outerBox = new QskLinearBox( Qt::Vertical );
+    outerBox->setMargins( 20 );
+    outerBox->setSpacing( 20 );
+#if 1
+    outerBox->setFixedSize( 700, 500 );
+#endif
+
+    setupControls( outerBox );
+    loadFontInfo();
+
+    Inherited::setContentItem( outerBox );
+}
+
+template< typename W >
+QskFontSelectionWindow< W >::~QskFontSelectionWindow() = default;
+
+template< typename W >
+QFont QskFontSelectionWindow< W >::selectedFont() const
+{
+    return m_data->selectedFont;
+}
+
+template< typename W >
+void QskFontSelectionWindow< W >::setupControls( QQuickItem* parentItem )
+{
+    auto* gridBox = new QskGridBox( parentItem );
+    gridBox->setSpacing( 10 );
+
+    const QskFontRole role( QskFontRole::Subtitle, QskFontRole::Normal );
+
+    auto* familyLabel = new QskTextLabel( "Family", gridBox );
+    familyLabel->setFontRole( role );
+    gridBox->addItem( familyLabel, 0, 0 );
+
+    auto* styleLabel = new QskTextLabel( "Style", gridBox );
+    styleLabel->setFontRole( role );
+    gridBox->addItem( styleLabel, 0, 1 );
+
+    auto* sizeLabel = new QskTextLabel( "Size", gridBox );
+    sizeLabel->setFontRole( role );
+    gridBox->addItem( sizeLabel, 0, 2 );
+
+    m_data->familyView = new QskSimpleListBox( gridBox );
+    m_data->familyView->setSizePolicy( Qt::Vertical, QskSizePolicy::Expanding );
+    gridBox->addItem( m_data->familyView, 1, 0 );
+
+    m_data->styleView = new QskSimpleListBox( gridBox );
+    m_data->styleView->setSizePolicy( Qt::Vertical, QskSizePolicy::Expanding );
+    gridBox->addItem( m_data->styleView, 1, 1 );
+
+    m_data->sizeView = new QskSimpleListBox( gridBox );
+    m_data->sizeView->setSizePolicy( Qt::Vertical, QskSizePolicy::Expanding );
+    gridBox->addItem( m_data->sizeView, 1, 2 );
+
+    auto* sampleLabel = new QskTextLabel( "Sample", gridBox );
+    sampleLabel->setFontRole( role );
+    gridBox->addItem( sampleLabel, 2, 0 );
+
+    m_data->outputLabel = new QskTextLabel( gridBox );
+    m_data->outputLabel->setSizePolicy( QskSizePolicy::Preferred, QskSizePolicy::Minimum );
+    m_data->outputLabel->setElideMode( Qt::ElideRight );
+    gridBox->addItem( m_data->outputLabel, 3, 0, 1, 3 );
+
+    gridBox->setColumnStretchFactor( 0, 5 );
+    gridBox->setColumnStretchFactor( 1, 3 );
+    gridBox->setColumnStretchFactor( 2, 2 );
+}
+
+template< typename W >
+void QskFontSelectionWindow< W >::loadFontInfo()
+{
+    const auto families = QFontDatabase::families();
+    m_data->familyView->setEntries( families );
+
+    QObject::connect( m_data->familyView, &QskSimpleListBox::selectedEntryChanged,
+        this, [this]( const QString& family )
+    {
+            const auto styles = QFontDatabase::styles( family );
+            m_data->styleView->setEntries( styles );
+    } );
+
+    QObject::connect( m_data->familyView, &QskSimpleListBox::selectedEntryChanged,
+        this, [this]( const QString& family )
+    {
+            const auto sizes = QFontDatabase::pointSizes( family );
+            QStringList sizesString;
+            sizesString.reserve( sizes.count() );
+
+            for( const auto size : sizes )
+            {
+                sizesString.append( QString::number( size ) );
+            }
+
+            m_data->sizeView->setEntries( sizesString );
+    } );
+
+    auto displaySample = [this]()
+    {
+        const auto family = m_data->familyView->selectedEntry();
+        const auto style = m_data->styleView->selectedEntry();
+        const auto size = m_data->sizeView->selectedEntry();
+
+        if( !family.isNull() && !style.isNull() && !size.isNull() )
+        {
+            auto& f = m_data->selectedFont;
+
+            f = QFont( family, size.toInt() );
+            f.setStyleName( style );
+
+            m_data->outputLabel->setSkinHint( QskTextLabel::Text | QskAspect::FontRole, f );
+            m_data->outputLabel->resetImplicitSize();
+            m_data->outputLabel->setText( "The quick brown fox jumps over the lazy dog" );
+        }
+        else
+        {
+            m_data->outputLabel->setText( {} );
+        }
+    };
+
+    QObject::connect( m_data->familyView, &QskSimpleListBox::selectedEntryChanged, this, displaySample );
+    QObject::connect( m_data->styleView, &QskSimpleListBox::selectedEntryChanged, this, displaySample );
+    QObject::connect( m_data->sizeView, &QskSimpleListBox::selectedEntryChanged, this, displaySample );
+}
+
+template class QskFontSelectionWindow< QskDialogWindow >;
+template class QskFontSelectionWindow< QskDialogSubWindow >;

--- a/src/dialogs/QskFontSelectionWindow.cpp
+++ b/src/dialogs/QskFontSelectionWindow.cpp
@@ -40,7 +40,7 @@ QskFontSelectionWindow< W >::QskFontSelectionWindow( QObject* parent, const QStr
 #endif
 
     setupControls( outerBox );
-    loadFontInfo();
+    connectSignals();
 
     Inherited::setContentItem( outerBox );
 }
@@ -101,7 +101,7 @@ void QskFontSelectionWindow< W >::setupControls( QQuickItem* parentItem )
 }
 
 template< typename W >
-void QskFontSelectionWindow< W >::loadFontInfo()
+void QskFontSelectionWindow< W >::connectSignals()
 {
     const auto families = QFontDatabase::families();
     m_data->familyView->setEntries( families );

--- a/src/dialogs/QskFontSelectionWindow.h
+++ b/src/dialogs/QskFontSelectionWindow.h
@@ -3,25 +3,28 @@
  *           SPDX-License-Identifier: BSD-3-Clause
  *****************************************************************************/
 
-#ifndef QSK_COLOR_SELECTION_WINDODW_H
-#define QSK_COLOR_SELECTION_WINDODW_H
+#ifndef QSK_FONT_SELECTION_WINDODW_H
+#define QSK_FONT_SELECTION_WINDODW_H
 
 #include "QskWindowOrSubWindow.h"
 
 template< typename W >
-class QskColorSelectionWindow : public QskWindowOrSubWindow< W >
+class QskFontSelectionWindow : public QskWindowOrSubWindow< W >
 {
     using Inherited = QskWindowOrSubWindow< W >;
 
   public:
 
-    QskColorSelectionWindow( QObject* parent, const QString& title,
+    QskFontSelectionWindow( QObject* parent, const QString& title,
         QskDialog::Actions actions, QskDialog::Action defaultAction );
-    ~QskColorSelectionWindow();
+    ~QskFontSelectionWindow();
 
-    QColor selectedColor() const;
+    QFont selectedFont() const;
 
   private:
+    void setupControls( QQuickItem* );
+    void loadFontInfo();
+
     class PrivateData;
     std::unique_ptr< PrivateData > m_data;
 };

--- a/src/dialogs/QskFontSelectionWindow.h
+++ b/src/dialogs/QskFontSelectionWindow.h
@@ -23,7 +23,7 @@ class QskFontSelectionWindow : public QskWindowOrSubWindow< W >
 
   private:
     void setupControls( QQuickItem* );
-    void loadFontInfo();
+    void connectSignals();
 
     class PrivateData;
     std::unique_ptr< PrivateData > m_data;

--- a/src/dialogs/QskWindowOrSubWindow.cpp
+++ b/src/dialogs/QskWindowOrSubWindow.cpp
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#include "QskWindowOrSubWindow.h"
+
+#include "QskDialogButtonBox.h"
+#include "QskFocusIndicator.h"
+
+static QskDialog::Action qskActionCandidate( const QskDialogButtonBox* buttonBox )
+{
+    // not the fastest code ever, but usually we always
+    // have a AcceptRole or YesRole button
+
+    const QskDialog::ActionRole candidates[] =
+    {
+        QskDialog::AcceptRole, QskDialog::YesRole,
+        QskDialog::RejectRole, QskDialog::NoRole, QskDialog::DestructiveRole,
+        QskDialog::UserRole, QskDialog::ResetRole,
+        QskDialog::ApplyRole, QskDialog::HelpRole
+    };
+
+    for ( auto role : candidates )
+    {
+        const auto& buttons = buttonBox->buttons( role );
+        if ( !buttons.isEmpty() )
+            return buttonBox->action( buttons.first() );
+    }
+
+    return QskDialog::NoAction;
+}
+
+static QskDialog::DialogCode qskExec( QskDialogWindow* dialogWindow )
+{
+#if 1
+    auto focusIndicator = new QskFocusIndicator();
+    focusIndicator->setObjectName( QStringLiteral( "DialogFocusIndicator" ) );
+    dialogWindow->addItem( focusIndicator );
+#endif
+
+    return dialogWindow->exec();
+}
+
+
+template< typename W >
+QskWindowOrSubWindow< W >::QskWindowOrSubWindow( QObject* parent, const QString& title,
+    QskDialog::Actions actions, QskDialog::Action defaultAction )
+    : W( parent, title, actions, defaultAction )
+{
+}
+
+
+QskWindowOrSubWindow< QskDialogWindow >::QskWindowOrSubWindow( QObject* parent, const QString& title,
+    QskDialog::Actions actions, QskDialog::Action defaultAction )
+    : QskDialogWindow( static_cast< QWindow* >( parent ) )
+{
+    auto* transientParent = static_cast< QWindow* >( parent );
+    setTransientParent( transientParent );
+
+    setTitle( title );
+    setDialogActions( actions );
+
+    if ( actions != QskDialog::NoAction && defaultAction == QskDialog::NoAction )
+        defaultAction = qskActionCandidate( buttonBox() );
+
+    setDefaultDialogAction( defaultAction );
+
+    setModality( transientParent ? Qt::WindowModal : Qt::ApplicationModal );
+
+    const QSize size = sizeConstraint();
+
+    if ( this->parent() )
+    {
+        QRect r( QPoint(), size );
+        r.moveCenter( QRect( QPoint(), this->parent()->size() ).center() );
+
+        setGeometry( r );
+    }
+
+    auto adjustSize = [this]()
+    {
+        const QSize size = sizeConstraint();
+
+        if ( size.isValid() )
+        {
+            setFlags( flags() | Qt::MSWindowsFixedSizeDialogHint );
+            setFixedSize( size );
+        }
+    };
+
+    connect( contentItem(), &QQuickItem::widthChanged, this, adjustSize );
+    connect( contentItem(), &QQuickItem::heightChanged, this, adjustSize );
+}
+
+QskDialog::DialogCode QskWindowOrSubWindow< QskDialogWindow >::exec()
+{
+    return qskExec( this );
+}
+
+void QskWindowOrSubWindow< QskDialogWindow >::setContentItem( QQuickItem* item )
+{
+    QskDialogWindow::setDialogContentItem( item );
+}
+
+QskWindowOrSubWindow< QskDialogSubWindow >::QskWindowOrSubWindow( QObject* parent, const QString& title,
+    QskDialog::Actions actions, QskDialog::Action defaultAction )
+    : QskDialogSubWindow( static_cast< QQuickWindow* >( parent )->contentItem() )
+{
+    setPopupFlag( QskPopup::DeleteOnClose );
+    setModal( true );
+    setTitle( title );
+    setDialogActions( actions );
+
+    if ( actions != QskDialog::NoAction && defaultAction == QskDialog::NoAction )
+        defaultAction = qskActionCandidate( buttonBox() );
+
+    setDefaultDialogAction( defaultAction );
+}
+
+QskDialog::DialogCode QskWindowOrSubWindow< QskDialogSubWindow >::exec()
+{
+    return QskDialogSubWindow::exec();
+}
+
+void QskWindowOrSubWindow< QskDialogSubWindow >::setContentItem( QQuickItem* item )
+{
+    QskDialogSubWindow::setContentItem( item );
+}

--- a/src/dialogs/QskWindowOrSubWindow.cpp
+++ b/src/dialogs/QskWindowOrSubWindow.cpp
@@ -8,6 +8,7 @@
 #include "QskDialogButtonBox.h"
 #include "QskFocusIndicator.h"
 
+// copied from QskDialog.cpp:
 static QskDialog::Action qskActionCandidate( const QskDialogButtonBox* buttonBox )
 {
     // not the fastest code ever, but usually we always

--- a/src/dialogs/QskWindowOrSubWindow.h
+++ b/src/dialogs/QskWindowOrSubWindow.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * QSkinny - Copyright (C) The authors
+ *           SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+#ifndef QSK_WINDOW_OR_SUBWINDOW_H
+#define QSK_WINDOW_OR_SUBWINDOW_H
+
+#include "QskDialogSubWindow.h"
+#include "QskDialogWindow.h"
+
+template< typename W >
+class QskWindowOrSubWindow : public W
+{
+  public:
+    QskWindowOrSubWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction );
+};
+
+template<>
+class QskWindowOrSubWindow< QskDialogWindow > : public QskDialogWindow
+{
+  public:
+    QskWindowOrSubWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction );
+
+    QskDialog::DialogCode exec();
+
+    void setContentItem( QQuickItem* item );
+};
+
+template<>
+class QskWindowOrSubWindow< QskDialogSubWindow > : public QskDialogSubWindow
+{
+  public:
+    QskWindowOrSubWindow( QObject* parent, const QString& title,
+        QskDialog::Actions actions, QskDialog::Action defaultAction );
+
+    QskDialog::DialogCode exec();
+
+    void setContentItem( QQuickItem* item );
+};
+
+#endif


### PR DESCRIPTION
## general:

* I introduced some private (non-exported) headers for the dialogs; I wonder whether we want to introduce a private folder to differentiate between exported and not exported classes?
* The templated class WindowOrSubwindow allows for the code to be written only once, see e.g. the class FileSelectionWindow. Otherwise we would have to duplicate the code like we do in QskMessage(Sub)Window and QskSelection(Sub)Window.
* For the above class I needed to copy some functions from QskDialog.cpp; maybe we should have them in a common place somewhere.
* I also copied code from Qsk(Sub)Window into QskWindowOrSubWindow; we should also decide how to deal with that.


## file / directory dialogs:

* In the file list view we needed to differentiate between single clicks and double clicks
* Two functions were copied from other parts and could be moved to QskFunctions or so:
    - qskRowAt() from QskListView.cpp
    - qskClonedMouseEvent() from QskGestureRecognizer.cpp


## color picker dialog:

* There was some work by Rick using shaders at https://github.com/vrcomputing/qskinny/tree/colorpicker .
  For now this has been implemented in software, i.e. filling the QImage pixel by pixel.