### PR TITLE
tab bar: Take scroll position into account when making item visible

### DIFF
--- a/src/controls/QskTabBar.cpp
+++ b/src/controls/QskTabBar.cpp
@@ -129,7 +129,7 @@ namespace
         {
             if ( qskIsAncestorOf( this, item ) )
             {
-                const auto pos = mapFromItem( item, QPointF() );
+                const auto pos = mapFromItem( item, QPointF() ) + scrollPos();
                 ensureVisible( QRectF( pos.x(), pos.y(), item->width(), item->height() ) );
             }
         }


### PR DESCRIPTION
If the tab bar is scrolled, the position we get from calling mapFromItem() is less than the real position with a scrolling of 0, because mapFromItem() does not know about our scroll position.

This is usually not noticed when creating a tab bar, because the scroll position is (0,0). When calling this method on a scrolled tab bar, the problem becomes visible.