### PR TITLE
shaders: Use different names for qt6_add_shaders calls

### DIFF
--- a/cmake/QskBuildFunctions.cmake
+++ b/cmake/QskBuildFunctions.cmake
@@ -149,7 +149,7 @@ function(qsk_add_example target)
 
 endfunction()
 
-function(qsk_add_shaders target)
+function(qsk_add_shaders target shader_name)
 
     cmake_parse_arguments( arg "" "" "FILES" ${ARGN} )
 
@@ -160,7 +160,7 @@ function(qsk_add_shaders target)
         list(APPEND outfiles "${qsbname}.qsb")
     endforeach()
 
-    qt6_add_shaders( ${target} "qskshaders" BATCHABLE PRECOMPILE QUIET
+    qt6_add_shaders( ${target} ${shader_name} BATCHABLE PRECOMPILE QUIET
         PREFIX "/qskinny/shaders" ${ARGV} OUTPUTS ${outfiles} )
 
     # pass on OUTPUT_TARGETS to the caller of this function

--- a/playground/shadows/CMakeLists.txt
+++ b/playground/shadows/CMakeLists.txt
@@ -35,6 +35,6 @@ if (QT_VERSION_MAJOR VERSION_GREATER_EQUAL 6)
         shaders/arcshadow-vulkan.vert
         shaders/arcshadow-vulkan.frag
     )
-    qsk_add_shaders( ${target} FILES ${SHADERS} OUTPUT_TARGETS shader_target)
+    qsk_add_shaders( ${target} "qskArcShaders" FILES ${SHADERS} OUTPUT_TARGETS shader_target)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,7 +510,7 @@ else()
 endif()
 
 if (QT_VERSION_MAJOR VERSION_GREATER_EQUAL 6)
-    qsk_add_shaders( ${target} FILES ${SHADERS} OUTPUT_TARGETS shader_target)
+    qsk_add_shaders( ${target} "qskshaders" FILES ${SHADERS} OUTPUT_TARGETS shader_target)
 endif()
 
 target_include_directories(${target} PUBLIC


### PR DESCRIPTION
Otherwise it won't work for WAsm.
According to the doc: "The name after the project has to be unique for each call."